### PR TITLE
✨ Fix: #72 LinkList Hang 오류 해결

### DIFF
--- a/TapTap/Projects/App/Sources/Navigation/AppCoordinator/Reducer/LinkListCoordinator.Reducer.swift
+++ b/TapTap/Projects/App/Sources/Navigation/AppCoordinator/Reducer/LinkListCoordinator.Reducer.swift
@@ -29,12 +29,12 @@ struct LinkListCoordinator: Reducer {
           state.path.append(.linkDetail(.init(article: articleItem)))
           return .none
           
-        case let .moveLink(allLinks, categoryName):
-          state.path.append(.movieLink(.init(allLinks: allLinks, categoryName: categoryName)))
+        case let .moveLink(allLinks, categoryName, totalCount):
+          state.path.append(.movieLink(.init(allLinks: allLinks, categoryName: categoryName, totalCount: totalCount)))
           return .none
           
-        case let .deleteLink(allLinks, categoryName):
-            state.path.append(.deleteLink(.init(allLinks: allLinks, categoryName: categoryName)))
+        case let .deleteLink(allLinks, categoryName, totalCount):
+            state.path.append(.deleteLink(.init(allLinks: allLinks, categoryName: categoryName, totalCount: totalCount)))
             return .none
           
         default:

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/ArticleFilterFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/ArticleFilterFeature.swift
@@ -28,12 +28,14 @@ public struct ArticleFilterFeature {
     case listCellTapped(ArticleItem)
     case listCellLongPressed(ArticleItem)
     case sortOrderChanged(SortOrder)
+    case loadMore
     
     case delegate(Delegate)
     public enum Delegate: Equatable {
       case openLinkDetail(ArticleItem)
       case longPressed(ArticleItem)
       case route(AppRoute)
+      case loadMore
     }
   }
   
@@ -45,6 +47,9 @@ public struct ArticleFilterFeature {
         
       case let .listCellLongPressed(link):
         return .send(.delegate(.longPressed(link)))
+        
+      case .loadMore:
+        return .send(.delegate(.loadMore))
         
       case let .sortOrderChanged(order):
         state.sortOrder = order

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/ArticleFilterFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/ArticleFilterFeature.swift
@@ -54,13 +54,6 @@ public struct ArticleFilterFeature {
         
       case let .sortOrderChanged(order):
         state.sortOrder = order
-        
-        switch order {
-        case .latest:
-          state.link.sort { $0.createAt > $1.createAt }
-        case .oldest:
-          state.link.sort { $0.createAt < $1.createAt }
-        }
         return .none
         
       case .delegate:

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/ArticleFilterFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/ArticleFilterFeature.swift
@@ -15,6 +15,7 @@ public struct ArticleFilterFeature {
   @ObservableState
   public struct State: Equatable {
     var link: [ArticleItem] = []
+    var totalCount: Int = 0
     var sortOrder: SortOrder = .latest
     var selectedLink: ArticleItem? = nil
   }

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/ArticleRowViewState.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/ArticleRowViewState.swift
@@ -1,0 +1,36 @@
+//
+//  ArticleRowViewState.swift
+//  LinkListFeature
+//
+//  Created by Hong on 4/12/26.
+//
+
+import Core
+
+struct ArticleRowViewState: Equatable, Identifiable {
+  let id: String
+  let article: ArticleItem
+  
+  let title: String
+  let category: String
+  let imageURL: String
+  let dateString: String
+  
+  init(article: ArticleItem) {
+    self.id = article.id
+    self.article = article
+    
+    self.title = article.title
+    self.category = article.category?.categoryName ?? "전체"
+    self.imageURL = article.imageURL ?? "notImage"
+    self.dateString = article.createAt.formattedKoreanDate()
+  }
+  
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.id == rhs.id &&
+    lhs.title == rhs.title &&
+    lhs.category == rhs.category &&
+    lhs.imageURL == rhs.imageURL &&
+    lhs.dateString == rhs.dateString
+  }
+}

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/DeleteLinkFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/DeleteLinkFeature.swift
@@ -21,16 +21,19 @@ public struct DeleteLinkFeature {
   public struct State: Equatable {
     var allLinks: [ArticleItem] = []
     var categoryName: String = "전체"
+    var totalCount: Int = 0
     var selectedLinks: Set<String> = []
     var isSelectAll: Bool = false
     var hideSelectControls: Bool = false
     
     public init(
       allLinks: [ArticleItem],
-      categoryName: String
+      categoryName: String,
+      totalCount: Int
     ) {
       self.allLinks = allLinks
       self.categoryName = categoryName
+      self.totalCount = totalCount
     }
   }
   

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/DeleteLinkFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/DeleteLinkFeature.swift
@@ -40,6 +40,7 @@ public struct DeleteLinkFeature {
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case onAppear
+    case fetchLinksResponse([ArticleItem])
     case toggleSelect(ArticleItem)
     case backButtonTapped
     case confirmDeleteTapped
@@ -57,8 +58,28 @@ public struct DeleteLinkFeature {
     Reduce { state, action in
       switch action {
       case .onAppear:
-        if state.hideSelectControls {
-          state.selectedLinks = Set(state.allLinks.map(\.id))
+        return .run { [categoryName = state.categoryName] send in
+          do {
+            let predicate: Foundation.Predicate<ArticleItem>?
+            if categoryName == "전체" {
+              predicate = nil
+            } else {
+              predicate = #Predicate<ArticleItem> { $0.category?.categoryName == categoryName }
+            }
+            let items = try swiftDataClient.link.fetchLinks(
+              predicate: predicate,
+              sortBy: [SortDescriptor(\.createAt, order: .reverse)]
+            )
+            await send(.fetchLinksResponse(items))
+          } catch {
+             print("fetch failed: \(error)")
+          }
+        }
+        
+      case let .fetchLinksResponse(items):
+        state.allLinks = items
+        if state.hideSelectControls || state.isSelectAll {
+          state.selectedLinks = Set(items.map(\.id))
           state.isSelectAll = true
         }
         return .none

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
@@ -133,6 +133,7 @@ private extension LinkListFeature {
     switch action {
 
     case .onAppear:
+      guard state.currentPage == 0 else { return .none }
       return .run { send in
         await send(.fetchCategories)
         await send(.fetchLinks)
@@ -355,6 +356,7 @@ private extension LinkListFeature {
       return .none
 
     case .fetchCategories:
+      guard state.bottomSheetCategories.isEmpty else { return .none }
       return .run { send in
         let items = try swiftDataClient.category.fetchCategories()
         await send(.responseCategoryItems(items))

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
@@ -294,7 +294,10 @@ private extension LinkListFeature {
           await send(.fetchLinksResponseFailed(error.localizedDescription))
         }
       }
-
+      
+    case .fetchLinksResponseFailed:
+      state.isFetching = false
+      return .send(.showAlert(title: "링크를 불러오지 못했어요", tint: .danger))
     case let .fetchLinksResponse(items):
       state.isFetching = false
 

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
@@ -315,10 +315,13 @@ private extension LinkListFeature {
       state.currentPage += 1
 
       let selectedName = state.selectedCategory?.categoryName ?? state.initialCategoryName
-      if selectedName == "전체" {
-        state.articleList.link = state.allLinks
-      } else {
-        state.articleList.link = state.allLinks.filter { $0.category?.categoryName == selectedName }
+      
+      let filteredLinks = selectedName == "전체" ? state.allLinks : state.allLinks.filter { $0.category?.categoryName == selectedName }
+      switch state.articleList.sortOrder {
+      case .latest:
+        state.articleList.link = filteredLinks.sorted { $0.createAt > $1.createAt }
+      case .oldest:
+        state.articleList.link = filteredLinks.sorted { $0.createAt < $1.createAt }
       }
 
       return .none

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
@@ -35,7 +35,13 @@ public struct LinkListFeature {
     var initialCategoryName: String = "전체"
 
     var bottomSheetCategories: IdentifiedArrayOf<CategoryProps> = []
-
+    
+    // 페이징 상태
+    var currentPage: Int = 0
+    let pageSize: Int = 50
+    var isFetching: Bool = false
+    var hasMore: Bool = true
+    
     // 시트 상태 관리
     @Presents var editSheet: EditSheetFeature.State?
     @Presents var selectBottomSheet: SelectBottomSheetFeature.State?
@@ -194,8 +200,8 @@ private extension LinkListFeature {
         state.selectedCategory = match
         state.categoryChipList.selectedCategory = match
         state.articleList.link = (name == "전체")
-          ? state.allLinks
-          : state.allLinks.filter { $0.category?.categoryName == name }
+        ? state.allLinks
+        : state.allLinks.filter { $0.category?.categoryName == name }
       } else {
         if let all = state.categoryChipList.categories.first(where: { $0.categoryName == "전체" }) {
           state.selectedCategory = all
@@ -248,6 +254,9 @@ private extension LinkListFeature {
     case let .articleList(.delegate(.route(route))):
       return .send(.delegate(.route(route)))
 
+    case .articleList(.delegate(.loadMore)):
+      return .send(.fetchLinks)
+
     case .refresh:
       return .send(.fetchLinks)
 
@@ -264,11 +273,21 @@ private extension LinkListFeature {
 private extension LinkListFeature {
   func dataReducer(state: inout State, action: Action) -> Effect<Action> {
     switch action {
-
     case .fetchLinks:
+      guard !state.isFetching && state.hasMore else { return .none }
+      state.isFetching = true
+      
+      let limit = state.pageSize
+      let offset = state.currentPage * state.pageSize
+      
       return .run { send in
+        await Task.yield()
+        
         do {
-          let items = try swiftDataClient.link.fetchLinks()
+          let items = try swiftDataClient.link.fetchLinks(
+            limit: limit,
+            offset: offset
+          )
           await send(.fetchLinksResponse(items))
         } catch {
           await send(.fetchLinksResponseFailed(error.localizedDescription))
@@ -276,21 +295,39 @@ private extension LinkListFeature {
       }
 
     case let .fetchLinksResponse(items):
-      let sorted = items.sorted { $0.createAt > $1.createAt }
-      state.allLinks = sorted
-      state.articleList.sortOrder = .latest
+      state.isFetching = false
+
+      if items.isEmpty {
+        state.hasMore = false
+        return .none
+      }
+
+      let existingURLs = Set(state.allLinks.map { $0.urlString })
+      let newItems = items.filter { !existingURLs.contains($0.urlString) }
+      
+      if newItems.isEmpty {
+        state.hasMore = false
+        return .none
+      }
+
+      state.allLinks.append(contentsOf: newItems)
+      state.currentPage += 1
 
       let selectedName = state.selectedCategory?.categoryName ?? state.initialCategoryName
       if selectedName == "전체" {
-        state.articleList.link = sorted
+        state.articleList.link = state.allLinks
       } else {
-        state.articleList.link = sorted.filter { $0.category?.categoryName == selectedName }
+        state.articleList.link = state.allLinks.filter { $0.category?.categoryName == selectedName }
       }
+
       return .none
 
-    case let .fetchLinksResponseFailed(error):
-      print("LinkList fetch failed:", error)
-      return .none
+    case .refresh:
+      state.currentPage = 0
+      state.allLinks = []
+      state.hasMore = true
+      state.isFetching = false
+      return .send(.fetchLinks)
 
     case .fetchCategories:
       return .run { send in
@@ -312,8 +349,8 @@ private extension LinkListFeature {
       state.categoryChipList.categories = chipCategories
 
       let target = state.initialCategoryName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        ? "전체"
-        : state.initialCategoryName
+      ? "전체"
+      : state.initialCategoryName
 
       if let match = chipCategories.first(where: { $0.categoryName == target }) {
         state.selectedCategory = match

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
@@ -257,9 +257,6 @@ private extension LinkListFeature {
     case .articleList(.delegate(.loadMore)):
       return .send(.fetchLinks)
 
-    case .refresh:
-      return .send(.fetchLinks)
-
     case .delegate:
       return .none
 

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
@@ -194,7 +194,8 @@ private extension LinkListFeature {
       }
       return .send(.delegate(.route(.moveLink(
         allLinks: state.articleList.link,
-        categoryName: state.selectedCategory?.categoryName ?? "전체"
+        categoryName: state.selectedCategory?.categoryName ?? "전체",
+        totalCount: state.articleList.totalCount
       ))))
 
     case let .moveToCategoryName(name):
@@ -227,7 +228,8 @@ private extension LinkListFeature {
       }
       return .send(.delegate(.route(.deleteLink(
         allLinks: state.articleList.link,
-        categoryName: state.selectedCategory?.categoryName ?? "전체"
+        categoryName: state.selectedCategory?.categoryName ?? "전체",
+        totalCount: state.articleList.totalCount
       ))))
 
     case let .showAlert(title, tint):

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
@@ -174,14 +174,7 @@ private extension LinkListFeature {
       state.categoryChipList.selectedCategory = category
       state.selectBottomSheet?.selectedCategory = category.categoryName
 
-      if category.categoryName == "전체" {
-        state.articleList.link = state.allLinks
-      } else {
-        state.articleList.link = state.allLinks.filter {
-          $0.category?.categoryName == category.categoryName
-        }
-      }
-      return .send(.fetchTotalCount)
+      return .send(.refresh)
 
     case .editSheet(.presented(.delegate(.dismissSheet))):
       state.editSheet = nil
@@ -205,9 +198,6 @@ private extension LinkListFeature {
       if let match = state.categoryChipList.categories.first(where: { $0.categoryName == name }) {
         state.selectedCategory = match
         state.categoryChipList.selectedCategory = match
-        state.articleList.link = (name == "전체")
-        ? state.allLinks
-        : state.allLinks.filter { $0.category?.categoryName == name }
       } else {
         if let all = state.categoryChipList.categories.first(where: { $0.categoryName == "전체" }) {
           state.selectedCategory = all
@@ -217,9 +207,8 @@ private extension LinkListFeature {
           state.selectedCategory = all
           state.categoryChipList.selectedCategory = all
         }
-        state.articleList.link = state.allLinks
       }
-      return .send(.fetchTotalCount)
+      return .send(.refresh)
 
     case .editSheet(.presented(.delegate(.deleteLink))):
       state.editSheet = nil
@@ -261,6 +250,9 @@ private extension LinkListFeature {
     case let .articleList(.delegate(.route(route))):
       return .send(.delegate(.route(route)))
 
+    case .articleList(.sortOrderChanged):
+      return .send(.refresh)
+
     case .articleList(.delegate(.loadMore)):
       return .send(.fetchLinks)
 
@@ -284,10 +276,25 @@ private extension LinkListFeature {
       let limit = state.pageSize
       let offset = state.currentPage * state.pageSize
       
+      let categoryName = state.selectedCategory?.categoryName ?? state.initialCategoryName
+      let sortOrder = state.articleList.sortOrder
+      
       return .run { send in
-        
         do {
+          let predicate: Foundation.Predicate<ArticleItem>?
+          if categoryName == "전체" {
+            predicate = nil
+          } else {
+            predicate = #Predicate<ArticleItem> { $0.category?.categoryName == categoryName }
+          }
+          
+          let sortDescs: [SortDescriptor<ArticleItem>] = sortOrder == .latest 
+            ? [SortDescriptor(\.createAt, order: .reverse)]
+            : [SortDescriptor(\.createAt, order: .forward)]
+            
           let items = try swiftDataClient.link.fetchLinks(
+            predicate: predicate,
+            sortBy: sortDescs,
             limit: limit,
             offset: offset
           )
@@ -305,6 +312,7 @@ private extension LinkListFeature {
 
       if items.isEmpty {
         state.hasMore = false
+        state.articleList.link = state.allLinks
         return .none
       }
 
@@ -313,27 +321,21 @@ private extension LinkListFeature {
       
       if newItems.isEmpty {
         state.hasMore = false
+        state.articleList.link = state.allLinks
         return .none
       }
 
       state.allLinks.append(contentsOf: newItems)
       state.currentPage += 1
 
-      let selectedName = state.selectedCategory?.categoryName ?? state.initialCategoryName
-      
-      let filteredLinks = selectedName == "전체" ? state.allLinks : state.allLinks.filter { $0.category?.categoryName == selectedName }
-      switch state.articleList.sortOrder {
-      case .latest:
-        state.articleList.link = filteredLinks.sorted { $0.createAt > $1.createAt }
-      case .oldest:
-        state.articleList.link = filteredLinks.sorted { $0.createAt < $1.createAt }
-      }
+      state.articleList.link = state.allLinks
 
       return .none
 
     case .refresh:
       state.currentPage = 0
       state.allLinks = []
+      state.articleList.link = []
       state.hasMore = true
       state.isFetching = false
       return .run { send in

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/LinkListFeature.swift
@@ -95,6 +95,9 @@ public struct LinkListFeature {
     case fetchLinksResponse([ArticleItem])
     case fetchLinksResponseFailed(String)
 
+    case fetchTotalCount
+    case fetchTotalCountResponse(Int)
+
     case fetchCategories
     case responseCategoryItems([CategoryItem])
 
@@ -133,6 +136,7 @@ private extension LinkListFeature {
       return .run { send in
         await send(.fetchCategories)
         await send(.fetchLinks)
+        await send(.fetchTotalCount)
       }
 
     case .backButtonTapped:
@@ -176,7 +180,7 @@ private extension LinkListFeature {
           $0.category?.categoryName == category.categoryName
         }
       }
-      return .none
+      return .send(.fetchTotalCount)
 
     case .editSheet(.presented(.delegate(.dismissSheet))):
       state.editSheet = nil
@@ -213,7 +217,7 @@ private extension LinkListFeature {
         }
         state.articleList.link = state.allLinks
       }
-      return .none
+      return .send(.fetchTotalCount)
 
     case .editSheet(.presented(.delegate(.deleteLink))):
       state.editSheet = nil
@@ -278,7 +282,6 @@ private extension LinkListFeature {
       let offset = state.currentPage * state.pageSize
       
       return .run { send in
-        await Task.yield()
         
         do {
           let items = try swiftDataClient.link.fetchLinks(
@@ -324,7 +327,32 @@ private extension LinkListFeature {
       state.allLinks = []
       state.hasMore = true
       state.isFetching = false
-      return .send(.fetchLinks)
+      return .run { send in
+        await send(.fetchLinks)
+        await send(.fetchTotalCount)
+      }
+
+    case .fetchTotalCount:
+      let categoryName = state.selectedCategory?.categoryName ?? state.initialCategoryName
+      return .run { send in
+        do {
+          let count: Int
+          if categoryName == "전체" {
+            count = try swiftDataClient.link.fetchLinksCount(predicate: nil)
+          } else {
+            count = try swiftDataClient.link.fetchLinksCount(
+              predicate: #Predicate<ArticleItem> { $0.category?.categoryName == categoryName }
+            )
+          }
+          await send(.fetchTotalCountResponse(count))
+        } catch {
+          print(error)
+        }
+      }
+
+    case let .fetchTotalCountResponse(count):
+      state.articleList.totalCount = count
+      return .none
 
     case .fetchCategories:
       return .run { send in

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/MoveLinkFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/MoveLinkFeature.swift
@@ -22,6 +22,7 @@ public struct MoveLinkFeature {
   public struct State: Equatable {
     var allLinks: [ArticleItem] = []
     var categoryName: String = "전체"
+    var totalCount: Int = 0
     var selectedLinks: Set<String> = []
     var isSelectAll: Bool = false
     var categories: [CategoryItem] = []
@@ -31,10 +32,12 @@ public struct MoveLinkFeature {
     
     public init(
       allLinks: [ArticleItem],
-      categoryName: String
+      categoryName: String,
+      totalCount: Int
     ) {
       self.allLinks = allLinks
       self.categoryName = categoryName
+      self.totalCount = totalCount
     }
   }
   

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/MoveLinkFeature.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Reducers/MoveLinkFeature.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftData
 
 import ComposableArchitecture
 
@@ -44,6 +45,7 @@ public struct MoveLinkFeature {
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case onAppear
+    case fetchLinksResponse([ArticleItem])
     case toggleSelect(ArticleItem)
     case backButtonTapped
     case confirmMoveTapped
@@ -66,6 +68,29 @@ public struct MoveLinkFeature {
       action in
       switch action {
       case .onAppear:
+        return .run { [categoryName = state.categoryName] send in
+          do {
+            let predicate: Foundation.Predicate<ArticleItem>?
+            if categoryName == "전체" {
+              predicate = nil
+            } else {
+              predicate = #Predicate<ArticleItem> { $0.category?.categoryName == categoryName }
+            }
+            let items = try swiftDataClient.link.fetchLinks(
+              predicate: predicate,
+              sortBy: [SortDescriptor(\.createAt, order: .reverse)]
+            )
+            await send(.fetchLinksResponse(items))
+          } catch {
+            print("Failed to fetch all links: \(error)")
+          }
+        }
+        
+      case let .fetchLinksResponse(items):
+        state.allLinks = items
+        if state.isSelectAll {
+          state.selectedLinks = Set(items.map(\.id))
+        }
         return .none
         
         /// 전체 선택 or 해제
@@ -123,12 +148,12 @@ public struct MoveLinkFeature {
         
         /// 시트에서 "선택하기"
       case .selectBottomSheet(.presented(.delegate(.categorySelected(let name)))):
-        guard let name,
-              let target = state.categories.first(where: { $0.categoryName == name })
-        else {
+        guard let name else {
           state.selectBottomSheet = nil
           return .none
         }
+        
+        let target = state.categories.first(where: { $0.categoryName == name })
         
         state.targetCategory = target
         let selected = state.allLinks.filter { state.selectedLinks.contains($0.id) }

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Views/ArticleFilterList.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Views/ArticleFilterList.swift
@@ -94,8 +94,10 @@ extension ArticleFilterList: View {
         .padding(.top, 120)
 
     } else {
-      ForEach(store.link) { article in
-        ArticleRowView(article: article, store: store)
+      LazyVStack(spacing: 0) {
+        ForEach(store.link) { article in
+          ArticleRowView(article: article, store: store)
+        }
       }
     }
   }

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Views/ArticleFilterList.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Views/ArticleFilterList.swift
@@ -40,7 +40,7 @@ extension ArticleFilterList: View {
           .font(.B1_M)
           .foregroundStyle(.caption1)
         
-        Text("\(store.link.count)")
+        Text("\(store.totalCount)")
           .font(.B1_SB)
           .foregroundStyle(.caption1)
         

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Views/ArticleFilterList.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Views/ArticleFilterList.swift
@@ -92,12 +92,23 @@ extension ArticleFilterList: View {
     if store.link.isEmpty {
       EmptyLinkView()
         .padding(.top, 120)
-
     } else {
       LazyVStack(spacing: 0) {
         ForEach(store.link) { article in
-          ArticleRowView(article: article, store: store)
+          ArticleRowView(article: article) {
+            store.send(.listCellTapped(article))
+          } onLongPress: {
+            store.send(.listCellLongPressed(article))
+          }
         }
+        
+        Color.clear
+          .frame(height: 1)
+          .onAppear {
+            DispatchQueue.main.async {
+              store.send(.loadMore)
+            }
+          }
       }
     }
   }

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Views/ArticleFilterRow.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Views/ArticleFilterRow.swift
@@ -12,10 +12,19 @@ import ComposableArchitecture
 import DesignSystem
 import Core
 
-struct ArticleRowView: View {
+struct ArticleRowView: View, Equatable {
   let article: ArticleItem
-  @Bindable var store: StoreOf<ArticleFilterFeature>
+//  @Bindable var store: StoreOf<ArticleFilterFeature>
+  let onTap: () -> Void
+  let onLongPress: () -> Void
   @State private var didLongPress = false
+  
+  static func == (lhs: ArticleRowView, rhs: ArticleRowView) -> Bool {
+    lhs.article.id == rhs.article.id &&
+    lhs.article.title == rhs.article.title &&
+    lhs.article.imageURL == rhs.article.imageURL &&
+    lhs.article.category?.categoryName == rhs.article.category?.categoryName
+  }
 
   var body: some View {
     ArticleCard(
@@ -29,7 +38,8 @@ struct ArticleRowView: View {
     .simultaneousGesture(
       TapGesture().onEnded {
         if !didLongPress {
-          store.send(.listCellTapped(article))
+//          store.send(.listCellTapped(article))
+          onTap()
         }
         didLongPress = false
       }
@@ -38,7 +48,8 @@ struct ArticleRowView: View {
       LongPressGesture(minimumDuration: 0.5)
         .onEnded { _ in
           didLongPress = true
-          store.send(.listCellLongPressed(article))
+//          store.send(.listCellLongPressed(article))
+          onLongPress()
         }
     )
     .padding(.bottom, 10)

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Views/DeleteLinkView.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Views/DeleteLinkView.swift
@@ -70,6 +70,7 @@ extension DeleteLinkView {
       .animation(.easeInOut(duration: 0.25), value: showAlertDialog)
     }
     .toolbar(.hidden)
+    .task { store.send(.onAppear) }
   }
   
   /// 링크 삭제하기 네비게이션바

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Views/DeleteLinkView.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Views/DeleteLinkView.swift
@@ -103,7 +103,7 @@ extension DeleteLinkView {
   /// 링크 개수 + 선택
   private var linkSelectView: some View {
     HStack(spacing: 10) {
-      Text("\(store.categoryName) (\(store.allLinks.count)개)")
+      Text("\(store.categoryName) (\(store.totalCount)개)")
         .font(.B2_M)
         .foregroundStyle(.caption3)
       

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Views/LinkListView.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Views/LinkListView.swift
@@ -69,7 +69,7 @@ extension LinkListView: View {
           if let name = info["categoryName"] as? String {
             store.send(.moveToCategoryName(name))
           }
-          store.send(.fetchLinks)
+          store.send(.refresh)
         }
       }
       .toolbar(.hidden)
@@ -82,7 +82,7 @@ extension LinkListView: View {
           let count = (notification.object as? [String: Int])?["deletedCount"] ?? 0
           let message = count == 1 ? "링크를 삭제했어요" : "\(count)개의 링크를 삭제했어요"
           store.send(.showAlert(title: message, tint: .danger))
-          store.send(.fetchLinks)
+          store.send(.refresh)
         }
       }
       .onDisappear {

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Views/LinkListView.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Views/LinkListView.swift
@@ -149,9 +149,7 @@ extension LinkListView: View {
   /// 카테고리 칩버튼 스크롤 + 기사 필터 스크롤
   private var scrollViewContents: some View {
     ScrollView(.vertical, showsIndicators: false) {
-      //      LazyVStack(spacing: .zero, pinnedViews: [.sectionHeaders]) {
-      //        Section {
-      VStack(spacing: 4) {
+      LazyVStack(spacing: 4) {
         Color.clear
           .frame(height: 0)
           .id("top")
@@ -171,10 +169,6 @@ extension LinkListView: View {
             )
         }
         .frame(height: 0)
-        
-        //        } header: {
-        //          gradientBar
-        //        }
       }
     }
     .coordinateSpace(name: "scroll")

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Views/MoveLinkView.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Views/MoveLinkView.swift
@@ -98,7 +98,7 @@ extension MoveLinkView {
   /// 링크 개수 + 선택
   private var linkSelectView: some View {
     HStack(spacing: 10) {
-      Text("\(store.categoryName) (\(store.allLinks.count)개)")
+      Text("\(store.categoryName) (\(store.totalCount)개)")
         .font(.B2_M)
         .foregroundStyle(.caption3)
       

--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Views/MoveLinkView.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Views/MoveLinkView.swift
@@ -63,6 +63,7 @@ extension MoveLinkView {
       }
     }
     .toolbar(.hidden)
+    .task { store.send(.onAppear) }
   }
   
   /// 링크 이동하기 네비게이션바

--- a/TapTap/Projects/Shared/Sources/Dependency/SwiftData/Repository/LinkRepository.swift
+++ b/TapTap/Projects/Shared/Sources/Dependency/SwiftData/Repository/LinkRepository.swift
@@ -42,8 +42,26 @@ public struct LinkRepository {
     )
   }
   
-  public func fetchLinks() throws -> [ArticleItem] {
-    try context.fetchAll(ArticleItem.self)
+  public func fetchLinks(
+    predicate: Predicate<ArticleItem>? = nil,
+    sortBy: [SortDescriptor<ArticleItem>] = [SortDescriptor(\.createAt, order: .reverse)],
+    limit: Int? = nil,
+    offset: Int? = nil
+  ) throws -> [ArticleItem] {
+    var descriptor = FetchDescriptor<ArticleItem>(
+      predicate: predicate,
+      sortBy: sortBy
+    )
+    
+    if let limit = limit {
+      descriptor.fetchLimit = limit
+    }
+    
+    if let offset = offset {
+      descriptor.fetchOffset = offset
+    }
+    
+    return try context.fetch(descriptor)
   }
   
   public func searchLinks(query: String) throws -> [ArticleItem] {

--- a/TapTap/Projects/Shared/Sources/Dependency/SwiftData/Repository/LinkRepository.swift
+++ b/TapTap/Projects/Shared/Sources/Dependency/SwiftData/Repository/LinkRepository.swift
@@ -63,6 +63,11 @@ public struct LinkRepository {
     
     return try context.fetch(descriptor)
   }
+
+  public func fetchLinksCount(predicate: Predicate<ArticleItem>? = nil) throws -> Int {
+    let descriptor = FetchDescriptor<ArticleItem>(predicate: predicate)
+    return try context.fetchCount(descriptor)
+  }
   
   public func searchLinks(query: String) throws -> [ArticleItem] {
     try context.fetchAll(

--- a/TapTap/Projects/Shared/Sources/Navigation/AppRoute.swift
+++ b/TapTap/Projects/Shared/Sources/Navigation/AppRoute.swift
@@ -41,8 +41,8 @@ public enum AppRoute: Equatable {
   
   // LinkListFeature
   case linkList(initCategory: String)
-  case moveLink(allLinks: [ArticleItem], categoryName: String)
-  case deleteLink(allLinks: [ArticleItem], categoryName: String)
+  case moveLink(allLinks: [ArticleItem], categoryName: String, totalCount: Int)
+  case deleteLink(allLinks: [ArticleItem], categoryName: String, totalCount: Int)
   
   // MyCategoryFeature
   case addCategory


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #72

---

### 🧶 주요 변경 내용 (Summary)

- 다량의 데이터 처리시 LinkList에서 스크롤 끊김 방지 에러 해결
- LinkList VStack -> LazyVStack수정
- Link를 50개씩 fetch하도록 수정

---

### 📸 스크린샷 

- List끊김 현상UI

https://github.com/user-attachments/assets/6a535ffe-b771-4d46-ae84-93f46e0b8396

- instruments 분석 결과 Hang 발생 현상

<img width="1822" height="1094" alt="스크린샷 2026-04-12 22 21 41" src="https://github.com/user-attachments/assets/d9b49bcc-11d0-452b-b800-5edc988afe08" />

- categoryChipFeature state가 중복으로 변경되는 현상 해결했습니다.

<img width="835" height="406" alt="스크린샷 2026-04-20 21 03 46" src="https://github.com/user-attachments/assets/be179154-df7f-444c-9386-2e39ccf0d806" />


---

### 🧪 테스트 / 검증 내역

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 26 환경에서 정상 동작
- [x] 스크롤시 동작 확인

---

### 💬 기타 공유 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 목록 끝 노출 시 자동으로 추가 기사 로드(무한 스크롤) 지원
  * 전체 카테고리 기준 총 기사 수를 서버에서 조회해 화면에 정확히 표시

* **사용자 인터페이스**
  * 기사 행 표시 안정화(제목/카테고리/이미지/날짜 표준화)
  * 이동/삭제 화면 헤더에 총 기사 수 반영
  * 목록 아이템이 화면 끝에 도달하면 더불어 로드 트리거 적용

* **성능**
  * 페이징과 중복 필터링으로 목록 로딩 효율 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->