### PR TITLE
Fix: #81 실행환경 macos26 tahoe로 지정

### DIFF
--- a/.github/workflows/iOS.yml
+++ b/.github/workflows/iOS.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   ios:
-    runs-on: macos-latest
+    runs-on: macos-26
     env:
       TUIST_VERSION: 4.57.1
     steps:
@@ -20,6 +20,9 @@ jobs:
     
     - name: Mise
       uses: jdx/mise-action@v2
+
+    - name: Xcode version
+      run: xcodebuild -version
       
     - uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #81 

---

### 🧶 주요 변경 내용 (Summary)
- CI용 yml파일 수정 

---


### 💬 기타 공유 사항
- liquid Glass 도입으로 기존 macos환경에서 빌드가 되지 않아서 맥OS 버전을 높여주었습니다.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * iOS 빌드 워크플로우 환경이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->