### PR TITLE
Refactor: #85 LinkList 스크롤 오프셋 감지 로직 개선

### DIFF
--- a/TapTap/Projects/Feature/LinkListFeature/Sources/Views/LinkListView.swift
+++ b/TapTap/Projects/Feature/LinkListFeature/Sources/Views/LinkListView.swift
@@ -22,7 +22,6 @@ public struct LinkListView {
   }
   
   @State private var showScrollToTopButton: Bool = false
-  @State private var initialOffsetY: CGFloat? = nil
 }
 
 // MARK: - View
@@ -160,27 +159,13 @@ extension LinkListView: View {
             action: \.articleList
           )
         )
-        
-        GeometryReader { geo in
-          Color.clear
-            .preference(
-              key: ScrollOffsetPreferenceKey.self,
-              value: geo.frame(in: .named("scroll")).minY
-            )
-        }
-        .frame(height: 0)
       }
     }
-    .coordinateSpace(name: "scroll")
-    .onPreferenceChange(ScrollOffsetPreferenceKey.self) { offsetY in
-      if initialOffsetY == nil {
-        initialOffsetY = offsetY
-      }
-      
-      guard let base = initialOffsetY else { return }
-      
+    .onScrollGeometryChange(for: CGFloat.self) { geometry in
+      geometry.contentOffset.y
+    } action: { _, offsetY in
       withAnimation(.easeInOut(duration: 0.2)) {
-        showScrollToTopButton = offsetY < base + 300
+        showScrollToTopButton = offsetY > 200
       }
     }
     .refreshable {
@@ -218,14 +203,6 @@ extension LinkListView: View {
     case .alert:
       return .bl3
     }
-  }
-}
-
-/// ScrollView의 스크롤 오프셋을 추적하기 위한 PreferenceKey
-private struct ScrollOffsetPreferenceKey: PreferenceKey {
-  static var defaultValue: CGFloat = 0
-  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-    value = nextValue()
   }
 }
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #85 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- GeometryReader와 PreferenceKey 기반 스크롤 감지 제거
- onScrollGeometryChange로 ScrollView contentOffset 직접 감지
- 200pt 이상 스크롤한 경우에만 최상단 이동 버튼 노출

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/837d2f32-1ef1-4aa2-ada8-b717272c50c9


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15, iOS 17.4 환경에서 정상 동작

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 링크 목록 스크롤 시 상단 이동 버튼의 위치 추적 메커니즘을 최적화하여 성능을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->