### PR TITLE
Feature: #96 AddLinkView 기능 구현

### DIFF
--- a/TapTap/Projects/App/Sources/Navigation/AppCoordinator/AppCoordinator.Path.swift
+++ b/TapTap/Projects/App/Sources/Navigation/AppCoordinator/AppCoordinator.Path.swift
@@ -59,4 +59,3 @@ extension AppCoordinator {
 
 extension AppCoordinator.Path.State: Equatable {}
 extension AppCoordinator.Path.Action: Equatable {}
-extension AppCoordinator.Path.CaseScope: ComposableArchitecture._CaseScopeProtocol {}

--- a/TapTap/Projects/App/Sources/Navigation/OnboardingCoordinator/OnboardingCoordinator.Path.swift
+++ b/TapTap/Projects/App/Sources/Navigation/OnboardingCoordinator/OnboardingCoordinator.Path.swift
@@ -23,4 +23,3 @@ extension OnboardingCoordinator {
 
 extension OnboardingCoordinator.Path.State: Equatable {}
 extension OnboardingCoordinator.Path.Action: Equatable {}
-extension OnboardingCoordinator.Path.CaseScope: ComposableArchitecture._CaseScopeProtocol {}

--- a/TapTap/Projects/MacFeature/SearchFeature/Sources/Views/SearchResultView.swift
+++ b/TapTap/Projects/MacFeature/SearchFeature/Sources/Views/SearchResultView.swift
@@ -30,7 +30,7 @@ public extension SearchResultView {
           SearchResultCard(
             title: item.title,
             date: formattedDate(item.createAt),
-            category: item.category?.categoryName ?? "-",
+            category: item.category?.categoryName ?? "전체",
             image: item.imageURL ?? "",
             action: {
               onTap(item)

--- a/TapTap/Projects/MacFeature/SearchFeature/Sources/Views/SearchView.swift
+++ b/TapTap/Projects/MacFeature/SearchFeature/Sources/Views/SearchView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+
 import Core
 import DesignSystem
 
@@ -6,14 +7,14 @@ public struct SearchView: View {
   @ObservedObject private var viewModel: SearchViewModel
   @State private var isDropdownOpen = false
   @State private var buttonFrame: CGRect = .zero
-  private let onTap: (ArticleItem) -> Void
+  private let onArticleTap: (ArticleItem) -> Void
   
   public init(
     viewModel: SearchViewModel,
-    onTap: @escaping (ArticleItem) -> Void
+    onArticleTap: @escaping (ArticleItem) -> Void = { _ in }
   ) {
     self.viewModel = viewModel
-    self.onTap = onTap
+    self.onArticleTap = onArticleTap
   }
 }
 
@@ -65,7 +66,7 @@ public extension SearchView {
           SearchResultView(
             items: viewModel.filteredResults,
             onTap: { item in
-              onTap(item)
+              onArticleTap(item)
             }
           )
         }

--- a/TapTap/Projects/TapTapMac/Sources/RootView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/RootView.swift
@@ -80,28 +80,8 @@ struct RootView: View {
       }
       
       ZStack(alignment: .top) {
-        VStack(spacing: 0) {
-          if selectedDetail == .linkList, !isLinkListEditing {
-            MacToolbar(
-              text: $searchViewModel.query,
-              onSearchTap: {
-                isSearchOverlayPresented = true
-                searchViewModel.focus()
-              }
-            )
-          }
-
-          if selectedDetail == .linkList, searchViewModel.hasSubmittedSearch {
-            SearchView(viewModel: searchViewModel) { item in
-              item.lastViewedDate = Date()
-              try? modelContext.save()
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-          } else {
-            detailContent
-          }
-        }
-
+        contentStack
+        
         if isSearchOverlayPresented {
           Color.black.opacity(0.16)
             .ignoresSafeArea()
@@ -188,6 +168,34 @@ struct RootView: View {
   
   private var categoriesForList: [CategoryItem] {
     allCategories.filter { !$0.isFavorite }
+  }
+
+  private var contentStack: some View {
+    VStack(spacing: 0) {
+      if selectedDetail == .linkList, !isLinkListEditing {
+        MacToolbar(
+          text: $searchViewModel.query,
+          onSearchTap: {
+            isSearchOverlayPresented = true
+            searchViewModel.focus()
+          }
+        )
+      }
+
+      if selectedDetail == .linkList, searchViewModel.hasSubmittedSearch {
+        searchContent
+      } else {
+        detailContent
+      }
+    }
+  }
+
+  private var searchContent: some View {
+    SearchView(viewModel: searchViewModel, onArticleTap: { item in
+      item.lastViewedDate = Date()
+      try? modelContext.save()
+    })
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
   }
 
   private func showAddCategoryPopover() {

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarHeaderView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarHeaderView.swift
@@ -13,11 +13,6 @@ struct SidebarHeaderView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 30) {
-      if !isCollapsed {
-        MacSidebarAssetImage(asset: MacSidebarAsset.wordmark)
-          .frame(width: 52, height: 12)
-      }
-
       HStack(spacing: 12) {
         if !isCollapsed {
           HStack(spacing: 12) {
@@ -38,7 +33,14 @@ struct SidebarHeaderView: View {
         .buttonStyle(.plain)
       }
       .padding(.bottom, isCollapsed ? 0 : 8)
+      .padding(.top, 50)
     }
     .frame(maxWidth: .infinity, alignment: .topLeading)
+  }
+}
+
+#Preview {
+  SidebarHeaderView(isCollapsed: false) {
+    
   }
 }


### PR DESCRIPTION
✨ What's this PR?

📌 관련 이슈 (Related Issue)
Closes #96

🧶 주요 변경 내용 (Summary)
- AddLinkView를 struct 단위로 분리해 뷰 구조를 정리했습니다.
- 링크 저장 성공 시 링크 목록 화면으로 전환하고 성공 토스트를 표시하도록 연결했습니다.
- 링크 저장 실패와 중복 링크 상황의 토스트 UI를 Figma 기준으로 맞췄습니다.
- 토스트 닫기 버튼의 hover 상태를 제거했습니다.

📸 스크린샷 (Optional)
- 추후 첨부 예정

🧪 테스트 / 검증 내역
- xcodebuild -workspace TapTap.xcworkspace -scheme TapTapMac -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
- macOS 시뮬레이터에서 Add Link 흐름 및 토스트 노출 확인

💬 기타 공유 사항
- PR 본문은 템플릿에 맞춰 정리했습니다.
- 영상이 필요하면 시뮬레이터 녹화로 추가할 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved search feature interface for better integration with the main navigation flow.
  * Simplified internal navigation coordinator architecture for enhanced maintainability.

* **Chores**
  * Updated code structure to align with latest architectural standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->