### PR TITLE
[#101] fix: 사이드바 수정

### DIFF
--- a/TapTap/Projects/App/Sources/Navigation/AppCoordinator/AppCoordinator.Path.swift
+++ b/TapTap/Projects/App/Sources/Navigation/AppCoordinator/AppCoordinator.Path.swift
@@ -17,7 +17,7 @@ import SearchFeature
 import SettingFeature
 
 extension AppCoordinator {
-  @Reducer(state: .equatable, action: .equatable)
+  @Reducer
   public enum Path {
     // AddLink
     case addLink(AddLinkFeature)
@@ -56,3 +56,7 @@ extension AppCoordinator {
     case openSourceList(OpenSourceListFeature)
   }
 }
+
+extension AppCoordinator.Path.State: Equatable {}
+extension AppCoordinator.Path.Action: Equatable {}
+extension AppCoordinator.Path.CaseScope: ComposableArchitecture._CaseScopeProtocol {}

--- a/TapTap/Projects/App/Sources/Navigation/OnboardingCoordinator/OnboardingCoordinator.Path.swift
+++ b/TapTap/Projects/App/Sources/Navigation/OnboardingCoordinator/OnboardingCoordinator.Path.swift
@@ -10,7 +10,7 @@ import ComposableArchitecture
 import OnboardingFeature
 
 extension OnboardingCoordinator {
-  @Reducer(state: .equatable, action: .equatable)
+  @Reducer
   public enum Path {
     case onboardingSafariSetting(OnboardingSafariSettingFeature)
     case onboardingHighlightMemo(OnboardingHighlightMemoFeature)
@@ -20,3 +20,7 @@ extension OnboardingCoordinator {
     case onboardingFinish(OnboardingFinishFeature)
   }
 }
+
+extension OnboardingCoordinator.Path.State: Equatable {}
+extension OnboardingCoordinator.Path.Action: Equatable {}
+extension OnboardingCoordinator.Path.CaseScope: ComposableArchitecture._CaseScopeProtocol {}

--- a/TapTap/Projects/Core/Sources/LinkService.swift
+++ b/TapTap/Projects/Core/Sources/LinkService.swift
@@ -1,0 +1,161 @@
+//
+//  LinkService.swift
+//  Core
+//
+//  Created by 홍 on 05/29/26.
+//
+
+import Foundation
+import SwiftData
+
+public struct LinkMetadata: Sendable {
+  public let title: String
+  public let imageURL: URL?
+  
+  public init(title: String, imageURL: URL?) {
+    self.title = title
+    self.imageURL = imageURL
+  }
+}
+
+public final class LinkService: Sendable {
+  public static let shared = LinkService()
+  
+  private init() {}
+  
+  public func extractMetadata(from url: URL) async throws -> LinkMetadata {
+    let htmlString = try await fetchHTML(from: url)
+    let title = try extractTitle(from: htmlString)
+    let imageURL = extractImageURL(from: htmlString, baseURL: url)
+    return LinkMetadata(title: title, imageURL: imageURL)
+  }
+  
+  private func fetchHTML(from url: URL) async throws -> String {
+    let (data, _) = try await URLSession.shared.data(from: url)
+    guard let htmlString = String(data: data, encoding: .utf8) else {
+      throw URLError(.cannotDecodeContentData)
+    }
+    return htmlString
+  }
+  
+  private func extractTitle(from htmlString: String) throws -> String {
+    let regex = try NSRegularExpression(pattern: "<title[^>]*>(.*?)</title>", options: [.caseInsensitive, .dotMatchesLineSeparators])
+    if let match = regex.firstMatch(in: htmlString, options: [], range: NSRange(location: 0, length: htmlString.utf16.count)) {
+      if let titleRange = Range(match.range(at: 1), in: htmlString) {
+        let title = String(htmlString[titleRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return title.decodeHtmlEntities()
+      }
+    }
+    throw URLError(.cannotParseResponse)
+  }
+  
+  private func extractImageURL(from htmlString: String, baseURL: URL) -> URL? {
+    guard let metaRegex = try? NSRegularExpression(
+      pattern: "<meta\\b[^>]*>",
+      options: [.caseInsensitive, .dotMatchesLineSeparators]
+    ) else { return nil }
+    
+    let metaMatches = metaRegex.matches(in: htmlString, options: [], range: NSRange(location: 0, length: htmlString.utf16.count))
+    for match in metaMatches {
+      guard let range = Range(match.range, in: htmlString) else { continue }
+      let attributes = Self.htmlAttributes(from: String(htmlString[range]))
+      let property = attributes["property"] ?? attributes["name"]
+      
+      if property?.lowercased() == "og:image",
+         let imageUrlString = attributes["content"],
+         let imageUrl = URL(string: imageUrlString, relativeTo: baseURL) {
+        return imageUrl
+      }
+    }
+    
+    guard let imgRegex = try? NSRegularExpression(
+      pattern: "<img[^>]*src=[\"']([^\"']+)[\"'][^>]*>",
+      options: [.caseInsensitive, .dotMatchesLineSeparators]
+    ) else { return nil }
+    
+    if let match = imgRegex.firstMatch(in: htmlString, options: [], range: NSRange(location: 0, length: htmlString.utf16.count)),
+       let range = Range(match.range(at: 1), in: htmlString) {
+      let imageUrlString = String(htmlString[range])
+      if let imageUrl = URL(string: imageUrlString, relativeTo: baseURL) {
+        return imageUrl
+      }
+    }
+    
+    return nil
+  }
+  
+  private static func htmlAttributes(from tag: String) -> [String: String] {
+    guard let attributeRegex = try? NSRegularExpression(
+      pattern: #"([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))"#,
+      options: [.caseInsensitive]
+    ) else { return [:] }
+    
+    var attributes: [String: String] = [:]
+    let matches = attributeRegex.matches(in: tag, range: NSRange(tag.startIndex..., in: tag))
+    for match in matches {
+      guard let keyRange = Range(match.range(at: 1), in: tag) else { continue }
+      
+      let valueRange = (2..<5)
+        .map { match.range(at: $0) }
+        .first { $0.location != NSNotFound }
+        .flatMap { Range($0, in: tag) }
+      
+      guard let valueRange else { continue }
+      attributes[String(tag[keyRange]).lowercased()] = String(tag[valueRange]).decodeHtmlEntities()
+    }
+    return attributes
+  }
+  
+  @MainActor
+  public func urlExists(_ urlString: String) throws -> Bool {
+    let container = AppGroupContainer.shared
+    let context = container.mainContext
+    let fetchDescriptor = FetchDescriptor<ArticleItem>(
+      predicate: #Predicate { $0.urlString == urlString }
+    )
+    return try context.fetch(fetchDescriptor).first != nil
+  }
+}
+
+extension String {
+  func decodeHtmlEntities() -> String {
+    var decoded = self
+    let namedEntities: [String: String] = [
+      "&amp;": "&",
+      "&quot;": "\"",
+      "&#39;": "'",
+      "&apos;": "'",
+      "&lt;": "<",
+      "&gt;": ">",
+      "&nbsp;": " "
+    ]
+    
+    for (entity, value) in namedEntities {
+      decoded = decoded.replacingOccurrences(of: entity, with: value)
+    }
+    
+    decoded = decoded.replacingNumericHtmlEntities(radix: 10, pattern: #"&#(\d+);"#)
+    decoded = decoded.replacingNumericHtmlEntities(radix: 16, pattern: #"&#x([0-9a-fA-F]+);"#)
+    return decoded
+  }
+  
+  private func replacingNumericHtmlEntities(radix: Int, pattern: String) -> String {
+    guard let regex = try? NSRegularExpression(pattern: pattern) else {
+      return self
+    }
+    
+    var result = self
+    let matches = regex.matches(in: self, range: NSRange(startIndex..., in: self))
+    for match in matches.reversed() {
+      guard
+        let fullRange = Range(match.range(at: 0), in: result),
+        let valueRange = Range(match.range(at: 1), in: result),
+        let scalarValue = UInt32(result[valueRange], radix: radix),
+        let scalar = UnicodeScalar(scalarValue)
+      else { continue }
+      
+      result.replaceSubrange(fullRange, with: String(scalar))
+    }
+    return result
+  }
+}

--- a/TapTap/Projects/Core/Sources/SwiftDataModel/CategoryItem.swift
+++ b/TapTap/Projects/Core/Sources/SwiftDataModel/CategoryItem.swift
@@ -20,4 +20,35 @@ public struct CategoryIcon: Codable, Hashable {
   }
 }
 
+public struct CategoryCommand {
+  private let context: ModelContext
+  
+  public init(context: ModelContext) {
+    self.context = context
+  }
+  
+  public func toggleFavorite(id: UUID) throws {
+    guard let category = try fetchCategory(id: id) else { return }
+    category.isFavorite.toggle()
+    try context.save()
+  }
+  
+  public func deleteCategory(id: UUID) throws {
+    guard let category = try fetchCategory(id: id) else { return }
+    category.links?.forEach { article in
+      article.category = nil
+    }
+    context.delete(category)
+    try context.save()
+  }
+  
+  private func fetchCategory(id: UUID) throws -> CategoryItem? {
+    let descriptor = FetchDescriptor<CategoryItem>(
+      predicate: #Predicate { $0.id == id }
+    )
+    
+    return try context.fetch(descriptor).first
+  }
+}
+
 // CategoryItem은 TapTapSchema.swift에서 VersionedSchema로 정의되어 있습니다.

--- a/TapTap/Projects/Feature/AddLinkFeature/Sources/Reducers/AddLinkFeature.swift
+++ b/TapTap/Projects/Feature/AddLinkFeature/Sources/Reducers/AddLinkFeature.swift
@@ -138,12 +138,11 @@ public struct AddLinkFeature {
         
         return .run { [linkURL = state.linkURL, selectedCategory = state.selectedCategory] send in
           do {
-            let title = try await extractTitle(from: url)
-            let image = try await extractImageURL(from: url)
+            let metadata = try await LinkService.shared.extractMetadata(from: url)
             let newLink = ArticleItem(
               urlString: linkURL,
-              title: title,
-              imageURL: image.absoluteString
+              title: metadata.title,
+              imageURL: metadata.imageURL?.absoluteString
             )
             if selectedCategory?.categoryName == "전체" {
               newLink.category = nil
@@ -196,7 +195,7 @@ public struct AddLinkFeature {
       case let .checkURLExists(urlString):
         return .run { send in
           do {
-            let exists = try await swiftDataClient.urlExists(urlString)
+            let exists = try await LinkService.shared.urlExists(urlString)
             await send(.didCheckURLExists(exists))
           } catch {
             await send(.didCheckURLExists(false))
@@ -242,66 +241,4 @@ public struct AddLinkFeature {
   }
   
   public init() {}
-  
-  //TODO: 함수들 어떻게 해야할지 생각해봐야함 SideEffect?
-  private func extractTitle(from url: URL) async throws -> String {
-    let (data, _) = try await URLSession.shared.data(from: url)
-    guard let htmlString = String(data: data, encoding: .utf8) else {
-      throw URLError(.cannotDecodeContentData)
-    }
-    
-    let regex = try NSRegularExpression(pattern: "<title[^>]*>(.*?)</title>", options: [.caseInsensitive, .dotMatchesLineSeparators])
-    if let match = regex.firstMatch(in: htmlString, options: [], range: NSRange(location: 0, length: htmlString.utf16.count)) {
-      if let titleRange = Range(match.range(at: 1), in: htmlString) {
-        let title = String(htmlString[titleRange]).trimmingCharacters(in: .whitespacesAndNewlines)
-        return title.decodeHtmlEntities()
-      }
-    }
-    throw URLError(.cannotParseResponse)
-  }
-}
-
-private func extractImageURL(from url: URL) async throws -> URL {
-  let (data, _) = try await URLSession.shared.data(from: url)
-  guard let htmlString = String(data: data, encoding: .utf8) else {
-    throw URLError(.cannotDecodeContentData)
-  }
-  
-  let ogImageRegex = try NSRegularExpression(
-    pattern: "<meta[^>]*property=[\"']og:image[\"'][^>]*content=[\"']([^\"']+)[\"'][^>]*>",
-    options: [.caseInsensitive, .dotMatchesLineSeparators]
-  )
-  if let match = ogImageRegex.firstMatch(in: htmlString, options: [], range: NSRange(location: 0, length: htmlString.utf16.count)),
-     let range = Range(match.range(at: 1), in: htmlString) {
-    let imageUrlString = String(htmlString[range])
-    if let imageUrl = URL(string: imageUrlString, relativeTo: url) {
-      return imageUrl
-    }
-  }
-  
-  let imgRegex = try NSRegularExpression(
-    pattern: "<img[^>]*src=[\"']([^\"']+)[\"'][^>]*>",
-    options: [.caseInsensitive, .dotMatchesLineSeparators]
-  )
-  if let match = imgRegex.firstMatch(in: htmlString, options: [], range: NSRange(location: 0, length: htmlString.utf16.count)),
-     let range = Range(match.range(at: 1), in: htmlString) {
-    let imageUrlString = String(htmlString[range])
-    if let imageUrl = URL(string: imageUrlString, relativeTo: url) {
-      return imageUrl
-    }
-  }
-  
-  throw URLError(.fileDoesNotExist)
-}
-
-extension SwiftDataClient {
-  @MainActor
-  func urlExists(_ urlString: String) throws -> Bool {
-    let container = AppGroupContainer.shared
-    let context = container.mainContext
-    let fetchDescriptor = FetchDescriptor<ArticleItem>(
-      predicate: #Predicate { $0.urlString == urlString }
-    )
-    return try context.fetch(fetchDescriptor).first != nil
-  }
 }

--- a/TapTap/Projects/MacFeature/AddLinkFeature/MacAddLinkFeature.xcodeproj/project.pbxproj
+++ b/TapTap/Projects/MacFeature/AddLinkFeature/MacAddLinkFeature.xcodeproj/project.pbxproj
@@ -8,11 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		01D37453566F73E270ADC4AC /* TuistBundle+MacAddLinkFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F8B56FAA7A5AC683C9C9504 /* TuistBundle+MacAddLinkFeature.swift */; };
+		06680AF4DB939281BF928B1C /* AddLinkMainContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09DB26A9BDFA22725315C7D /* AddLinkMainContentView.swift */; };
+		0CF559B9D0014FB6D310045F /* AddLinkCategoryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEAA456B2502EB5FEF78CAC /* AddLinkCategoryCard.swift */; };
 		1D5D5297F3C3F1506C4FFB6A /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D071AC581F6BC3DDB4AEE6 /* App.swift */; };
-		1F3A01B941C84D08A9C7B621 /* AddLinkMainContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C640882A9124311B8B470AC /* AddLinkMainContentView.swift */; };
 		2560F743D8CCE41B838F6982 /* AddLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9F09155093C5A5C46F5291 /* AddLinkView.swift */; };
-		2B1F0CE5972B4AFD9B892B66 /* AddLinkCategoryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C82726EA3143F28A19D8C0 /* AddLinkCategoryCard.swift */; };
-		36C14603C7684099B5D2E78F /* AddLinkToastViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D35C057ED54D29B04E2E64 /* AddLinkToastViews.swift */; };
 		39D4E88012568387B1D04E51 /* Core_Core.bundle in Resources */ = {isa = PBXBuildFile; fileRef = E1C029EDF2B310920368E9E8 /* Core_Core.bundle */; };
 		484BE41D5AF3CAD3370C4CC6 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42326CCDAD038E3E54917D25 /* Core.framework */; };
 		48D484FBFB6D723634BE8A1E /* DesignSystem_DesignSystem.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 414EAE793A5F9C6ED43BDF09 /* DesignSystem_DesignSystem.bundle */; };
@@ -22,6 +21,7 @@
 		68A05E1956C962BD13223D69 /* _LottieStub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3F0071DFD3FBC82E385D814 /* _LottieStub.framework */; };
 		76E6C47D2FE13BBEE5BE349E /* Core_Core.bundle in Resources */ = {isa = PBXBuildFile; fileRef = E1C029EDF2B310920368E9E8 /* Core_Core.bundle */; };
 		782E7FD9B1EE6493A8CAB421 /* _LottieStub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3F0071DFD3FBC82E385D814 /* _LottieStub.framework */; };
+		78EA98686B8AAAD0B9A3001C /* DesignSystem.framework in Dependencies */ = {isa = PBXBuildFile; fileRef = E3CED1A6850DEDBA7DAED97E /* DesignSystem.framework */; };
 		808E073B2336868F1070C4C9 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42326CCDAD038E3E54917D25 /* Core.framework */; };
 		8F21318426D25F0D330FEDF3 /* DesignSystem_DesignSystem.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 414EAE793A5F9C6ED43BDF09 /* DesignSystem_DesignSystem.bundle */; };
 		9069D19E11786E517AD206AA /* Lottie.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EBD1D0E858AFBD725858922F /* Lottie.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -33,6 +33,7 @@
 		BF7FD844E3A266E1B9894AE2 /* DesignSystem_DesignSystem.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 414EAE793A5F9C6ED43BDF09 /* DesignSystem_DesignSystem.bundle */; };
 		CB17C2C86EDC840B83AE1C37 /* MacAddLinkFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF6E53642E4164C67123B6A5 /* MacAddLinkFeature.framework */; };
 		CCE7046EEAD31D4EFA5CDF08 /* Core.framework in Dependencies */ = {isa = PBXBuildFile; fileRef = 42326CCDAD038E3E54917D25 /* Core.framework */; };
+		CE8B01AAAA7796E976CB4342 /* AddLinkToastViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D8CFC9A7D2040BFF57FF38 /* AddLinkToastViews.swift */; };
 		D110F396C91A8C6539E08293 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3CED1A6850DEDBA7DAED97E /* DesignSystem.framework */; };
 		D8849A4DE960E32E992E4E71 /* Lottie.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBD1D0E858AFBD725858922F /* Lottie.xcframework */; };
 		E2547D6DDF239F8C759D18A3 /* Lottie.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBD1D0E858AFBD725858922F /* Lottie.xcframework */; };
@@ -84,6 +85,7 @@
 			dstSubfolderSpec = 16;
 			files = (
 				CCE7046EEAD31D4EFA5CDF08 /* Core.framework in Dependencies */,
+				78EA98686B8AAAD0B9A3001C /* DesignSystem.framework in Dependencies */,
 			);
 			name = Dependencies;
 			runOnlyForDeploymentPostprocessing = 1;
@@ -154,19 +156,19 @@
 		619CB9C0E13211DDC439B82D /* MacAddLinkFeature_MacAddLinkFeature-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "MacAddLinkFeature_MacAddLinkFeature-Info.plist"; sourceTree = "<group>"; };
 		6881ABE55B78B3324DAB6ADD /* placeholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = placeholder.swift; sourceTree = "<group>"; };
 		6E3BCA51273D9519B8A754FE /* MacAddLinkFeature-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "MacAddLinkFeature-Info.plist"; sourceTree = "<group>"; };
-		7C640882A9124311B8B470AC /* AddLinkMainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkMainContentView.swift; sourceTree = "<group>"; };
-		83C82726EA3143F28A19D8C0 /* AddLinkCategoryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkCategoryCard.swift; sourceTree = "<group>"; };
 		98A436B860A74D172EA6635F /* MacAddLinkFeatureExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MacAddLinkFeatureExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A9F09155093C5A5C46F5291 /* AddLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkView.swift; sourceTree = "<group>"; };
 		A3F0071DFD3FBC82E385D814 /* _LottieStub.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = _LottieStub.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5CBAC7E341287946B00014F /* AddLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkTests.swift; sourceTree = "<group>"; };
 		B79D9FE8A6B18B4EF1BEE0DB /* MacAddLinkFeatureExample-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "MacAddLinkFeatureExample-Info.plist"; sourceTree = "<group>"; };
-		C4D35C057ED54D29B04E2E64 /* AddLinkToastViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkToastViews.swift; sourceTree = "<group>"; };
+		DAEAA456B2502EB5FEF78CAC /* AddLinkCategoryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkCategoryCard.swift; sourceTree = "<group>"; };
 		DF6E53642E4164C67123B6A5 /* MacAddLinkFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MacAddLinkFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1C029EDF2B310920368E9E8 /* Core_Core.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Core_Core.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3CED1A6850DEDBA7DAED97E /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EBD1D0E858AFBD725858922F /* Lottie.xcframework */ = {isa = PBXFileReference; expectedSignature = "SelfSigned:892F1B43047B50538F2F46EAD92900DD3D4811F3582178C061A5FB20F111CB26"; lastKnownFileType = wrapper.xcframework; path = Lottie.xcframework; sourceTree = "<group>"; };
 		F03D24A174338ED884DE72B0 /* MacAddLinkFeatureTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "MacAddLinkFeatureTests-Info.plist"; sourceTree = "<group>"; };
+		F09DB26A9BDFA22725315C7D /* AddLinkMainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkMainContentView.swift; sourceTree = "<group>"; };
+		F2D8CFC9A7D2040BFF57FF38 /* AddLinkToastViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkToastViews.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -246,9 +248,9 @@
 		2FF306CFD7B12D6AD85933EA /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				83C82726EA3143F28A19D8C0 /* AddLinkCategoryCard.swift */,
-				7C640882A9124311B8B470AC /* AddLinkMainContentView.swift */,
-				C4D35C057ED54D29B04E2E64 /* AddLinkToastViews.swift */,
+				DAEAA456B2502EB5FEF78CAC /* AddLinkCategoryCard.swift */,
+				F09DB26A9BDFA22725315C7D /* AddLinkMainContentView.swift */,
+				F2D8CFC9A7D2040BFF57FF38 /* AddLinkToastViews.swift */,
 				9A9F09155093C5A5C46F5291 /* AddLinkView.swift */,
 			);
 			path = Sources;
@@ -541,9 +543,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				01D37453566F73E270ADC4AC /* TuistBundle+MacAddLinkFeature.swift in Sources */,
-				2B1F0CE5972B4AFD9B892B66 /* AddLinkCategoryCard.swift in Sources */,
-				1F3A01B941C84D08A9C7B621 /* AddLinkMainContentView.swift in Sources */,
-				36C14603C7684099B5D2E78F /* AddLinkToastViews.swift in Sources */,
+				0CF559B9D0014FB6D310045F /* AddLinkCategoryCard.swift in Sources */,
+				06680AF4DB939281BF928B1C /* AddLinkMainContentView.swift in Sources */,
+				CE8B01AAAA7796E976CB4342 /* AddLinkToastViews.swift in Sources */,
 				2560F743D8CCE41B838F6982 /* AddLinkView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TapTap/Projects/MacFeature/AddLinkFeature/MacAddLinkFeature.xcodeproj/project.pbxproj
+++ b/TapTap/Projects/MacFeature/AddLinkFeature/MacAddLinkFeature.xcodeproj/project.pbxproj
@@ -1,0 +1,987 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 60;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		01D37453566F73E270ADC4AC /* TuistBundle+MacAddLinkFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F8B56FAA7A5AC683C9C9504 /* TuistBundle+MacAddLinkFeature.swift */; };
+		1D5D5297F3C3F1506C4FFB6A /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D071AC581F6BC3DDB4AEE6 /* App.swift */; };
+		1F3A01B941C84D08A9C7B621 /* AddLinkMainContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C640882A9124311B8B470AC /* AddLinkMainContentView.swift */; };
+		2560F743D8CCE41B838F6982 /* AddLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9F09155093C5A5C46F5291 /* AddLinkView.swift */; };
+		2B1F0CE5972B4AFD9B892B66 /* AddLinkCategoryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C82726EA3143F28A19D8C0 /* AddLinkCategoryCard.swift */; };
+		36C14603C7684099B5D2E78F /* AddLinkToastViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D35C057ED54D29B04E2E64 /* AddLinkToastViews.swift */; };
+		39D4E88012568387B1D04E51 /* Core_Core.bundle in Resources */ = {isa = PBXBuildFile; fileRef = E1C029EDF2B310920368E9E8 /* Core_Core.bundle */; };
+		484BE41D5AF3CAD3370C4CC6 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42326CCDAD038E3E54917D25 /* Core.framework */; };
+		48D484FBFB6D723634BE8A1E /* DesignSystem_DesignSystem.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 414EAE793A5F9C6ED43BDF09 /* DesignSystem_DesignSystem.bundle */; };
+		560063ECC665ADC32B84E825 /* Core_Core.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = E1C029EDF2B310920368E9E8 /* Core_Core.bundle */; };
+		5E5DD4268958CC400F891509 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3CED1A6850DEDBA7DAED97E /* DesignSystem.framework */; };
+		60A4A8FB205AB582F4D81011 /* MacAddLinkFeature_MacAddLinkFeature.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 0A8F3F4DBFE88C48F32A014C /* MacAddLinkFeature_MacAddLinkFeature.bundle */; };
+		68A05E1956C962BD13223D69 /* _LottieStub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3F0071DFD3FBC82E385D814 /* _LottieStub.framework */; };
+		76E6C47D2FE13BBEE5BE349E /* Core_Core.bundle in Resources */ = {isa = PBXBuildFile; fileRef = E1C029EDF2B310920368E9E8 /* Core_Core.bundle */; };
+		782E7FD9B1EE6493A8CAB421 /* _LottieStub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3F0071DFD3FBC82E385D814 /* _LottieStub.framework */; };
+		808E073B2336868F1070C4C9 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 42326CCDAD038E3E54917D25 /* Core.framework */; };
+		8F21318426D25F0D330FEDF3 /* DesignSystem_DesignSystem.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 414EAE793A5F9C6ED43BDF09 /* DesignSystem_DesignSystem.bundle */; };
+		9069D19E11786E517AD206AA /* Lottie.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EBD1D0E858AFBD725858922F /* Lottie.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9981FAC7982098810574911B /* DesignSystem_DesignSystem.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 414EAE793A5F9C6ED43BDF09 /* DesignSystem_DesignSystem.bundle */; };
+		A43AD1C5CF63FCC76D3348A9 /* MacAddLinkFeature_MacAddLinkFeature.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0A8F3F4DBFE88C48F32A014C /* MacAddLinkFeature_MacAddLinkFeature.bundle */; };
+		A9557A80FE7D7D00DB9867F3 /* Core_Core.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = E1C029EDF2B310920368E9E8 /* Core_Core.bundle */; };
+		AEA4B037CB69F3493C838C61 /* MacAddLinkFeature_MacAddLinkFeature.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0A8F3F4DBFE88C48F32A014C /* MacAddLinkFeature_MacAddLinkFeature.bundle */; };
+		BAC23AD33036C632336810A9 /* AddLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5CBAC7E341287946B00014F /* AddLinkTests.swift */; };
+		BF7FD844E3A266E1B9894AE2 /* DesignSystem_DesignSystem.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 414EAE793A5F9C6ED43BDF09 /* DesignSystem_DesignSystem.bundle */; };
+		CB17C2C86EDC840B83AE1C37 /* MacAddLinkFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF6E53642E4164C67123B6A5 /* MacAddLinkFeature.framework */; };
+		CCE7046EEAD31D4EFA5CDF08 /* Core.framework in Dependencies */ = {isa = PBXBuildFile; fileRef = 42326CCDAD038E3E54917D25 /* Core.framework */; };
+		D110F396C91A8C6539E08293 /* DesignSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3CED1A6850DEDBA7DAED97E /* DesignSystem.framework */; };
+		D8849A4DE960E32E992E4E71 /* Lottie.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBD1D0E858AFBD725858922F /* Lottie.xcframework */; };
+		E2547D6DDF239F8C759D18A3 /* Lottie.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBD1D0E858AFBD725858922F /* Lottie.xcframework */; };
+		EB1650D67CF5BD6D3E54001F /* MacAddLinkFeature.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF6E53642E4164C67123B6A5 /* MacAddLinkFeature.framework */; };
+		EB29A87882D31CF1AB7970E3 /* MacAddLinkFeature_MacAddLinkFeature.bundle in Dependencies */ = {isa = PBXBuildFile; fileRef = 0A8F3F4DBFE88C48F32A014C /* MacAddLinkFeature_MacAddLinkFeature.bundle */; };
+		FB82FDA80D484AD2C3C23D0E /* placeholder.swift in Resources */ = {isa = PBXBuildFile; fileRef = 6881ABE55B78B3324DAB6ADD /* placeholder.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		248AF3378773BE047C283241 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7A083CA5D87382C3DFC89E50 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6FB7CC0B21CE46E54EB13117;
+			remoteInfo = MacAddLinkFeature;
+		};
+		3FDA09854C35535484BDFB8F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7A083CA5D87382C3DFC89E50 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FF2DB6B32C622AB068EBCC7F;
+			remoteInfo = MacAddLinkFeature_MacAddLinkFeature;
+		};
+		6228812567EC0E87D019E70A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7A083CA5D87382C3DFC89E50 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6FB7CC0B21CE46E54EB13117;
+			remoteInfo = MacAddLinkFeature;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		12E638A131EB24579C10147D /* Dependencies */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstSubfolderSpec = 16;
+			files = (
+				A9557A80FE7D7D00DB9867F3 /* Core_Core.bundle in Dependencies */,
+				BF7FD844E3A266E1B9894AE2 /* DesignSystem_DesignSystem.bundle in Dependencies */,
+				60A4A8FB205AB582F4D81011 /* MacAddLinkFeature_MacAddLinkFeature.bundle in Dependencies */,
+			);
+			name = Dependencies;
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		430ECC9E34A6607B703D4520 /* Dependencies */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstSubfolderSpec = 16;
+			files = (
+				CCE7046EEAD31D4EFA5CDF08 /* Core.framework in Dependencies */,
+			);
+			name = Dependencies;
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		671824C7FF0733613042F774 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		859EFB3AED0C0E9BD7E9852F /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				9069D19E11786E517AD206AA /* Lottie.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AB84375C1C072E54406E5646 /* Dependencies */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstSubfolderSpec = 16;
+			files = (
+				560063ECC665ADC32B84E825 /* Core_Core.bundle in Dependencies */,
+				8F21318426D25F0D330FEDF3 /* DesignSystem_DesignSystem.bundle in Dependencies */,
+				EB29A87882D31CF1AB7970E3 /* MacAddLinkFeature_MacAddLinkFeature.bundle in Dependencies */,
+			);
+			name = Dependencies;
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		D2CB607D380C65ACE608F6EE /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB223F3F42EC14D6143C154C /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		05214402EBFC923223261A8C /* MacAddLinkFeatureTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacAddLinkFeatureTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0A8F3F4DBFE88C48F32A014C /* MacAddLinkFeature_MacAddLinkFeature.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacAddLinkFeature_MacAddLinkFeature.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		0D1392DF7FEE3FD8A85C262D /* Project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Project.xcconfig; sourceTree = "<group>"; };
+		0F8B56FAA7A5AC683C9C9504 /* TuistBundle+MacAddLinkFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TuistBundle+MacAddLinkFeature.swift"; sourceTree = "<group>"; };
+		414EAE793A5F9C6ED43BDF09 /* DesignSystem_DesignSystem.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DesignSystem_DesignSystem.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		42326CCDAD038E3E54917D25 /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		55D071AC581F6BC3DDB4AEE6 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+		619CB9C0E13211DDC439B82D /* MacAddLinkFeature_MacAddLinkFeature-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "MacAddLinkFeature_MacAddLinkFeature-Info.plist"; sourceTree = "<group>"; };
+		6881ABE55B78B3324DAB6ADD /* placeholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = placeholder.swift; sourceTree = "<group>"; };
+		6E3BCA51273D9519B8A754FE /* MacAddLinkFeature-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "MacAddLinkFeature-Info.plist"; sourceTree = "<group>"; };
+		7C640882A9124311B8B470AC /* AddLinkMainContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkMainContentView.swift; sourceTree = "<group>"; };
+		83C82726EA3143F28A19D8C0 /* AddLinkCategoryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkCategoryCard.swift; sourceTree = "<group>"; };
+		98A436B860A74D172EA6635F /* MacAddLinkFeatureExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MacAddLinkFeatureExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A9F09155093C5A5C46F5291 /* AddLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkView.swift; sourceTree = "<group>"; };
+		A3F0071DFD3FBC82E385D814 /* _LottieStub.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = _LottieStub.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B5CBAC7E341287946B00014F /* AddLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkTests.swift; sourceTree = "<group>"; };
+		B79D9FE8A6B18B4EF1BEE0DB /* MacAddLinkFeatureExample-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "MacAddLinkFeatureExample-Info.plist"; sourceTree = "<group>"; };
+		C4D35C057ED54D29B04E2E64 /* AddLinkToastViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLinkToastViews.swift; sourceTree = "<group>"; };
+		DF6E53642E4164C67123B6A5 /* MacAddLinkFeature.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MacAddLinkFeature.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1C029EDF2B310920368E9E8 /* Core_Core.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Core_Core.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		E3CED1A6850DEDBA7DAED97E /* DesignSystem.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DesignSystem.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EBD1D0E858AFBD725858922F /* Lottie.xcframework */ = {isa = PBXFileReference; expectedSignature = "SelfSigned:892F1B43047B50538F2F46EAD92900DD3D4811F3582178C061A5FB20F111CB26"; lastKnownFileType = wrapper.xcframework; path = Lottie.xcframework; sourceTree = "<group>"; };
+		F03D24A174338ED884DE72B0 /* MacAddLinkFeatureTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "MacAddLinkFeatureTests-Info.plist"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		16CB657CFBAFE4E5A0816D25 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				484BE41D5AF3CAD3370C4CC6 /* Core.framework in Frameworks */,
+				D110F396C91A8C6539E08293 /* DesignSystem.framework in Frameworks */,
+				EB1650D67CF5BD6D3E54001F /* MacAddLinkFeature.framework in Frameworks */,
+				782E7FD9B1EE6493A8CAB421 /* _LottieStub.framework in Frameworks */,
+				D8849A4DE960E32E992E4E71 /* Lottie.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3681E5219E0381947C5398EF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A8175C9E5FC6F16E3EBACC63 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FC7F2A49757986140E8E0748 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				808E073B2336868F1070C4C9 /* Core.framework in Frameworks */,
+				5E5DD4268958CC400F891509 /* DesignSystem.framework in Frameworks */,
+				CB17C2C86EDC840B83AE1C37 /* MacAddLinkFeature.framework in Frameworks */,
+				68A05E1956C962BD13223D69 /* _LottieStub.framework in Frameworks */,
+				E2547D6DDF239F8C759D18A3 /* Lottie.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1B303427B32F22EFDE13913B /* artifacts */ = {
+			isa = PBXGroup;
+			children = (
+				509C4CA65321A4305773A572 /* lottie-spm */,
+			);
+			path = artifacts;
+			sourceTree = "<group>";
+		};
+		2032687D062B277A22DD5212 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				B5CBAC7E341287946B00014F /* AddLinkTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		24D113CB3D50FFF98E20A6C0 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				55D071AC581F6BC3DDB4AEE6 /* App.swift */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		2CD5A5C8848585A2807071E4 /* Lottie */ = {
+			isa = PBXGroup;
+			children = (
+				EBD1D0E858AFBD725858922F /* Lottie.xcframework */,
+			);
+			path = Lottie;
+			sourceTree = "<group>";
+		};
+		2FF306CFD7B12D6AD85933EA /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				83C82726EA3143F28A19D8C0 /* AddLinkCategoryCard.swift */,
+				7C640882A9124311B8B470AC /* AddLinkMainContentView.swift */,
+				C4D35C057ED54D29B04E2E64 /* AddLinkToastViews.swift */,
+				9A9F09155093C5A5C46F5291 /* AddLinkView.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		4916D267F2F2FCCE71E89A31 /* .build */ = {
+			isa = PBXGroup;
+			children = (
+				1B303427B32F22EFDE13913B /* artifacts */,
+			);
+			path = .build;
+			sourceTree = "<group>";
+		};
+		509C4CA65321A4305773A572 /* lottie-spm */ = {
+			isa = PBXGroup;
+			children = (
+				2CD5A5C8848585A2807071E4 /* Lottie */,
+			);
+			path = "lottie-spm";
+			sourceTree = "<group>";
+		};
+		5CC57DD170D65965E2E3F4B7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				0F8B56FAA7A5AC683C9C9504 /* TuistBundle+MacAddLinkFeature.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		7026F60AC914536F2B25676C /* Tuist */ = {
+			isa = PBXGroup;
+			children = (
+				4916D267F2F2FCCE71E89A31 /* .build */,
+				EE2C6B4D41D30214A21CAAD8 /* Config */,
+			);
+			name = Tuist;
+			path = ../../../Tuist;
+			sourceTree = "<group>";
+		};
+		80B4F7F3BF2D09D71145A9EB = {
+			isa = PBXGroup;
+			children = (
+				D4539676A6DAD737C50C1DAC /* Project */,
+				8F62DA641FF8365DF4646B54 /* Products */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			wrapsLines = 1;
+		};
+		8F62DA641FF8365DF4646B54 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A3F0071DFD3FBC82E385D814 /* _LottieStub.framework */,
+				E1C029EDF2B310920368E9E8 /* Core_Core.bundle */,
+				42326CCDAD038E3E54917D25 /* Core.framework */,
+				414EAE793A5F9C6ED43BDF09 /* DesignSystem_DesignSystem.bundle */,
+				E3CED1A6850DEDBA7DAED97E /* DesignSystem.framework */,
+				0A8F3F4DBFE88C48F32A014C /* MacAddLinkFeature_MacAddLinkFeature.bundle */,
+				DF6E53642E4164C67123B6A5 /* MacAddLinkFeature.framework */,
+				98A436B860A74D172EA6635F /* MacAddLinkFeatureExample.app */,
+				05214402EBFC923223261A8C /* MacAddLinkFeatureTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CA4E100AA1A9D5FF5FCC25BA /* InfoPlists */ = {
+			isa = PBXGroup;
+			children = (
+				619CB9C0E13211DDC439B82D /* MacAddLinkFeature_MacAddLinkFeature-Info.plist */,
+				6E3BCA51273D9519B8A754FE /* MacAddLinkFeature-Info.plist */,
+				B79D9FE8A6B18B4EF1BEE0DB /* MacAddLinkFeatureExample-Info.plist */,
+				F03D24A174338ED884DE72B0 /* MacAddLinkFeatureTests-Info.plist */,
+			);
+			path = InfoPlists;
+			sourceTree = "<group>";
+		};
+		D4539676A6DAD737C50C1DAC /* Project */ = {
+			isa = PBXGroup;
+			children = (
+				DCF107E0087C56EB285CF635 /* Derived */,
+				24D113CB3D50FFF98E20A6C0 /* Example */,
+				E7746A79493636359B98590F /* Resources */,
+				2FF306CFD7B12D6AD85933EA /* Sources */,
+				2032687D062B277A22DD5212 /* Tests */,
+				7026F60AC914536F2B25676C /* Tuist */,
+			);
+			name = Project;
+			sourceTree = "<group>";
+		};
+		DCF107E0087C56EB285CF635 /* Derived */ = {
+			isa = PBXGroup;
+			children = (
+				CA4E100AA1A9D5FF5FCC25BA /* InfoPlists */,
+				5CC57DD170D65965E2E3F4B7 /* Sources */,
+			);
+			path = Derived;
+			sourceTree = "<group>";
+		};
+		E7746A79493636359B98590F /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				6881ABE55B78B3324DAB6ADD /* placeholder.swift */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		EE2C6B4D41D30214A21CAAD8 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				0D1392DF7FEE3FD8A85C262D /* Project.xcconfig */,
+			);
+			path = Config;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		522D70A0CC9C5396BA917892 /* MacAddLinkFeatureExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 862AB864AC7C4D9A3621F8D4 /* Build configuration list for PBXNativeTarget "MacAddLinkFeatureExample" */;
+			buildPhases = (
+				B799CAD45FC5B0B8B6B6BCB4 /* Sources */,
+				98BD8B5378AC58785567DE34 /* Resources */,
+				16CB657CFBAFE4E5A0816D25 /* Frameworks */,
+				859EFB3AED0C0E9BD7E9852F /* Embed Frameworks */,
+				12E638A131EB24579C10147D /* Dependencies */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				532A48DB433EF13A5E825E9F /* PBXTargetDependency */,
+			);
+			name = MacAddLinkFeatureExample;
+			packageProductDependencies = (
+			);
+			productName = MacAddLinkFeatureExample;
+			productReference = 98A436B860A74D172EA6635F /* MacAddLinkFeatureExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		6FB7CC0B21CE46E54EB13117 /* MacAddLinkFeature */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 66AF0F5BD7C358458340D1EC /* Build configuration list for PBXNativeTarget "MacAddLinkFeature" */;
+			buildPhases = (
+				8FD708E3B08A6DAF4B9B18A3 /* Sources */,
+				7E2F8F65DC6BBD7E039E11B3 /* Resources */,
+				3681E5219E0381947C5398EF /* Frameworks */,
+				D2CB607D380C65ACE608F6EE /* Embed Frameworks */,
+				430ECC9E34A6607B703D4520 /* Dependencies */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7BE4F05400478954E42CA0FA /* PBXTargetDependency */,
+			);
+			name = MacAddLinkFeature;
+			packageProductDependencies = (
+			);
+			productName = MacAddLinkFeature;
+			productReference = DF6E53642E4164C67123B6A5 /* MacAddLinkFeature.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		B47CFF5ECD4DABD347BD460E /* MacAddLinkFeatureTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 40CFDECF2CFF954D49EA809B /* Build configuration list for PBXNativeTarget "MacAddLinkFeatureTests" */;
+			buildPhases = (
+				034A9A52AC9106CFDC698A40 /* Sources */,
+				5781F1B9437AA96F73978C22 /* Resources */,
+				FC7F2A49757986140E8E0748 /* Frameworks */,
+				671824C7FF0733613042F774 /* Embed Frameworks */,
+				AB84375C1C072E54406E5646 /* Dependencies */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5597ADC7039BDA806EC15A87 /* PBXTargetDependency */,
+			);
+			name = MacAddLinkFeatureTests;
+			packageProductDependencies = (
+			);
+			productName = MacAddLinkFeatureTests;
+			productReference = 05214402EBFC923223261A8C /* MacAddLinkFeatureTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		FF2DB6B32C622AB068EBCC7F /* MacAddLinkFeature_MacAddLinkFeature */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 45C747C39F5456426D9DF7B6 /* Build configuration list for PBXNativeTarget "MacAddLinkFeature_MacAddLinkFeature" */;
+			buildPhases = (
+				6562A08FFBDFE606A2C32700 /* Sources */,
+				C85713A7585B74C87796120D /* Resources */,
+				A8175C9E5FC6F16E3EBACC63 /* Frameworks */,
+				EB223F3F42EC14D6143C154C /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MacAddLinkFeature_MacAddLinkFeature;
+			packageProductDependencies = (
+			);
+			productName = MacAddLinkFeature_MacAddLinkFeature;
+			productReference = 0A8F3F4DBFE88C48F32A014C /* MacAddLinkFeature_MacAddLinkFeature.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7A083CA5D87382C3DFC89E50 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+			};
+			buildConfigurationList = D7DCEEB7DECE5A12EEE84106 /* Build configuration list for PBXProject "MacAddLinkFeature" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 80B4F7F3BF2D09D71145A9EB;
+			productRefGroup = 8F62DA641FF8365DF4646B54 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6FB7CC0B21CE46E54EB13117 /* MacAddLinkFeature */,
+				522D70A0CC9C5396BA917892 /* MacAddLinkFeatureExample */,
+				B47CFF5ECD4DABD347BD460E /* MacAddLinkFeatureTests */,
+				FF2DB6B32C622AB068EBCC7F /* MacAddLinkFeature_MacAddLinkFeature */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5781F1B9437AA96F73978C22 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				76E6C47D2FE13BBEE5BE349E /* Core_Core.bundle in Resources */,
+				48D484FBFB6D723634BE8A1E /* DesignSystem_DesignSystem.bundle in Resources */,
+				A43AD1C5CF63FCC76D3348A9 /* MacAddLinkFeature_MacAddLinkFeature.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7E2F8F65DC6BBD7E039E11B3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		98BD8B5378AC58785567DE34 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				39D4E88012568387B1D04E51 /* Core_Core.bundle in Resources */,
+				9981FAC7982098810574911B /* DesignSystem_DesignSystem.bundle in Resources */,
+				AEA4B037CB69F3493C838C61 /* MacAddLinkFeature_MacAddLinkFeature.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C85713A7585B74C87796120D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB82FDA80D484AD2C3C23D0E /* placeholder.swift in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		034A9A52AC9106CFDC698A40 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BAC23AD33036C632336810A9 /* AddLinkTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6562A08FFBDFE606A2C32700 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8FD708E3B08A6DAF4B9B18A3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				01D37453566F73E270ADC4AC /* TuistBundle+MacAddLinkFeature.swift in Sources */,
+				2B1F0CE5972B4AFD9B892B66 /* AddLinkCategoryCard.swift in Sources */,
+				1F3A01B941C84D08A9C7B621 /* AddLinkMainContentView.swift in Sources */,
+				36C14603C7684099B5D2E78F /* AddLinkToastViews.swift in Sources */,
+				2560F743D8CCE41B838F6982 /* AddLinkView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B799CAD45FC5B0B8B6B6BCB4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1D5D5297F3C3F1506C4FFB6A /* App.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		532A48DB433EF13A5E825E9F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = MacAddLinkFeature;
+			target = 6FB7CC0B21CE46E54EB13117 /* MacAddLinkFeature */;
+			targetProxy = 248AF3378773BE047C283241 /* PBXContainerItemProxy */;
+		};
+		5597ADC7039BDA806EC15A87 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = MacAddLinkFeature;
+			target = 6FB7CC0B21CE46E54EB13117 /* MacAddLinkFeature */;
+			targetProxy = 6228812567EC0E87D019E70A /* PBXContainerItemProxy */;
+		};
+		7BE4F05400478954E42CA0FA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = MacAddLinkFeature_MacAddLinkFeature;
+			target = FF2DB6B32C622AB068EBCC7F /* MacAddLinkFeature_MacAddLinkFeature */;
+			targetProxy = 3FDA09854C35535484BDFB8F /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		1E67372F1928086B78AA948C /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D1392DF7FEE3FD8A85C262D /* Project.xcconfig */;
+			buildSettings = {
+				APS_ENVIRONMENT = production;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "$(CODE_SIGN_IDENTITY)";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../../Tuist/.build/artifacts/lottie-spm/Lottie",
+				);
+				INFOPLIST_FILE = "Derived/InfoPlists/MacAddLinkFeatureExample-Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "탭탭";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Nbs.dev.ADA.app;
+				PRODUCT_NAME = MacAddLinkFeatureExample;
+				PROVISIONING_PROFILE_SPECIFIER = "$(PROV_PROFILE_APP_RELEASE)";
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		2934018A483B0A87F60D42CD /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D1392DF7FEE3FD8A85C262D /* Project.xcconfig */;
+			buildSettings = {
+				APS_ENVIRONMENT = production;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "$(CODE_SIGN_IDENTITY)";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "Derived/InfoPlists/MacAddLinkFeature-Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = MacAddLinkFeature;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Nbs.dev.app.MacAddLinkFeature;
+				PRODUCT_NAME = MacAddLinkFeature;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		33A8D48D1379CBB7E029DD96 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D1392DF7FEE3FD8A85C262D /* Project.xcconfig */;
+			buildSettings = {
+				APS_ENVIRONMENT = development;
+				CODE_SIGN_IDENTITY = "$(CODE_SIGN_IDENTITY)";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../../Tuist/.build/artifacts/lottie-spm/Lottie",
+				);
+				INFOPLIST_FILE = "Derived/InfoPlists/MacAddLinkFeatureTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+					"$(SRCROOT)/../../../Tuist/.build/artifacts/lottie-spm/Lottie",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Nbs.dev.app.MacAddLinkFeatureTests;
+				PRODUCT_NAME = MacAddLinkFeatureTests;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_COMPILATION_MODE = singlefile;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		3871B82872E22F1452703087 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D1392DF7FEE3FD8A85C262D /* Project.xcconfig */;
+			buildSettings = {
+				APS_ENVIRONMENT = development;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconDev;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "$(CODE_SIGN_IDENTITY)";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../../Tuist/.build/artifacts/lottie-spm/Lottie",
+				);
+				INFOPLIST_FILE = "Derived/InfoPlists/MacAddLinkFeatureExample-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Nbs.dev.app;
+				PRODUCT_NAME = MacAddLinkFeatureExample;
+				PROVISIONING_PROFILE_SPECIFIER = "$(PROV_PROFILE_APP_DEV)";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_COMPILATION_MODE = singlefile;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		4F5D2F79ECEEA99429F62222 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_IDENTITY = "-";
+				GENERATE_MASTER_OBJECT_FILE = NO;
+				INFOPLIST_FILE = "Derived/InfoPlists/MacAddLinkFeature_MacAddLinkFeature-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Nbs.dev.app.MacAddLinkFeature.generated.resources;
+				PRODUCT_NAME = MacAddLinkFeature_MacAddLinkFeature;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "";
+			};
+			name = Release;
+		};
+		5C1F2977513A0AD4D8269C97 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D1392DF7FEE3FD8A85C262D /* Project.xcconfig */;
+			buildSettings = {
+				APS_ENVIRONMENT = development;
+				CODE_SIGN_IDENTITY = "$(CODE_SIGN_IDENTITY)";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "Derived/InfoPlists/MacAddLinkFeature-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Nbs.dev.app.MacAddLinkFeature;
+				PRODUCT_NAME = MacAddLinkFeature;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_COMPILATION_MODE = singlefile;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5F04595215FCC0FD87B1DA5C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		776367E7B9C7221BE9D1EAEA /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D1392DF7FEE3FD8A85C262D /* Project.xcconfig */;
+			buildSettings = {
+				APS_ENVIRONMENT = production;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "$(CODE_SIGN_IDENTITY)";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../../../Tuist/.build/artifacts/lottie-spm/Lottie",
+				);
+				INFOPLIST_FILE = "Derived/InfoPlists/MacAddLinkFeatureTests-Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = MacAddLinkFeatureTests;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+					"$(SRCROOT)/../../../Tuist/.build/artifacts/lottie-spm/Lottie",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Nbs.dev.app.MacAddLinkFeatureTests;
+				PRODUCT_NAME = MacAddLinkFeatureTests;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		BC30E05FBB3366AAAE99373B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_IDENTITY = "-";
+				GENERATE_MASTER_OBJECT_FILE = NO;
+				INFOPLIST_FILE = "Derived/InfoPlists/MacAddLinkFeature_MacAddLinkFeature-Info.plist";
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Nbs.dev.app.MacAddLinkFeature.generated.resources;
+				PRODUCT_NAME = MacAddLinkFeature_MacAddLinkFeature;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_COMPILATION_MODE = singlefile;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "";
+			};
+			name = Debug;
+		};
+		D91E79DCBE2CB39B892D2469 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		40CFDECF2CFF954D49EA809B /* Build configuration list for PBXNativeTarget "MacAddLinkFeatureTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33A8D48D1379CBB7E029DD96 /* Debug */,
+				776367E7B9C7221BE9D1EAEA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		45C747C39F5456426D9DF7B6 /* Build configuration list for PBXNativeTarget "MacAddLinkFeature_MacAddLinkFeature" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC30E05FBB3366AAAE99373B /* Debug */,
+				4F5D2F79ECEEA99429F62222 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		66AF0F5BD7C358458340D1EC /* Build configuration list for PBXNativeTarget "MacAddLinkFeature" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5C1F2977513A0AD4D8269C97 /* Debug */,
+				2934018A483B0A87F60D42CD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		862AB864AC7C4D9A3621F8D4 /* Build configuration list for PBXNativeTarget "MacAddLinkFeatureExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3871B82872E22F1452703087 /* Debug */,
+				1E67372F1928086B78AA948C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D7DCEEB7DECE5A12EEE84106 /* Build configuration list for PBXProject "MacAddLinkFeature" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5F04595215FCC0FD87B1DA5C /* Debug */,
+				D91E79DCBE2CB39B892D2469 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7A083CA5D87382C3DFC89E50 /* Project object */;
+}

--- a/TapTap/Projects/MacFeature/AddLinkFeature/Project.swift
+++ b/TapTap/Projects/MacFeature/AddLinkFeature/Project.swift
@@ -18,7 +18,8 @@ let project = Project.project(
       sources: .sources,
       resources: .default,
       dependencies: [
-        .core()
+        .core(),
+        .designSystem()
       ]
     ),
     Target.target(

--- a/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkCategoryCard.swift
+++ b/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkCategoryCard.swift
@@ -1,0 +1,57 @@
+//
+//  AddLinkCategoryCard.swift
+//  MacAddLinkFeature
+//
+//  Created by 홍 on 05/31/26.
+//
+
+import SwiftUI
+
+import DesignSystem
+
+struct AddLinkCategoryCard: View {
+  let title: String
+  let countText: String?
+  let iconNumber: Int?
+  let isSelected: Bool
+  let action: () -> Void
+  
+  @State private var isHovered: Bool = false
+  
+  var body: some View {
+    Button(action: action) {
+      ZStack(alignment: .bottomTrailing) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text(title)
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(Color.text1)
+            .lineLimit(2)
+            .frame(maxWidth: .infinity, alignment: .leading)
+          
+          Text(countText ?? "0개")
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(isSelected ? Color.caption1 : Color.caption2)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        
+        DesignSystemAsset.primaryCategoryIcon(number: iconNumber ?? 1)
+          .resizable()
+          .scaledToFit()
+          .frame(width: 56, height: 56)
+          .offset(x: 2, y: 2)
+      }
+      .padding(16)
+      .frame(height: 116)
+      .frame(minWidth: 140, maxWidth: .infinity)
+      .background(isSelected || isHovered ? Color.bl1 : Color.n0)
+      .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+      .overlay {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .strokeBorder(isSelected ? Color.bl6 : .clear, lineWidth: 1.5)
+      }
+      .shadow(color: Color.bgShadow3, radius: 8, x: 0, y: 0)
+    }
+    .buttonStyle(.plain)
+    .onHover { isHovered = $0 }
+  }
+}

--- a/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkMainContentView.swift
+++ b/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkMainContentView.swift
@@ -1,0 +1,242 @@
+//
+//  AddLinkMainContentView.swift
+//  MacAddLinkFeature
+//
+//  Created by 홍 on 05/31/26.
+//
+
+import SwiftUI
+
+import Core
+import DesignSystem
+
+struct AddLinkMainContentView: View {
+  let categories: [CategoryItem]
+  let totalLinkCount: Int
+  let isSaving: Bool
+  let canSubmit: Bool
+  let onAdd: () -> Void
+  let onAddCategory: () -> Void
+  let onLinkURLChanged: () -> Void
+  
+  @Binding var linkURL: String
+  @Binding var selectedCategoryID: UUID?
+  
+  var body: some View {
+    VStack(spacing: 20) {
+      AddLinkTopBar(
+        isSaving: isSaving,
+        canSubmit: canSubmit,
+        onAdd: onAdd
+      )
+      
+      VStack(spacing: 24) {
+        AddLinkAddressSection(
+          linkURL: $linkURL,
+          onLinkURLChanged: onLinkURLChanged
+        )
+        
+        AddLinkCategorySection(
+          categories: categories,
+          totalLinkCount: totalLinkCount,
+          onAddCategory: onAddCategory,
+          selectedCategoryID: $selectedCategoryID
+        )
+      }
+      .frame(width: 600)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+  }
+}
+
+private struct AddLinkTopBar: View {
+  let isSaving: Bool
+  let canSubmit: Bool
+  let onAdd: () -> Void
+  
+  var body: some View {
+    ZStack {
+      Text("링크 추가하기")
+        .font(.system(size: 16, weight: .semibold))
+        .foregroundStyle(Color.text1)
+      
+      HStack {
+        Spacer()
+        
+        Button(action: onAdd) {
+          AddLinkSubmitButtonLabel(isSaving: isSaving)
+            .foregroundStyle(canSubmit ? Color.bl6 : Color.caption2)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 9)
+            .background(canSubmit ? Color.bl1 : Color.n40)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .disabled(!canSubmit)
+      }
+      .padding(.trailing, 32)
+    }
+    .padding(.bottom, 20)
+    .frame(maxWidth: .infinity)
+    .background(Color.n0)
+    .overlay(alignment: .bottom) {
+      Rectangle()
+        .fill(Color.divider1)
+        .frame(height: 1)
+    }
+  }
+}
+
+private struct AddLinkSubmitButtonLabel: View {
+  let isSaving: Bool
+  
+  var body: some View {
+    HStack(spacing: 6) {
+      if isSaving {
+        ProgressView()
+          .controlSize(.small)
+          .frame(width: 15, height: 15)
+      } else {
+        Image(systemName: "plus")
+          .font(.system(size: 15, weight: .semibold))
+      }
+      
+      Text(isSaving ? "추가 중" : "추가")
+        .font(.system(size: 16, weight: .semibold))
+    }
+  }
+}
+
+private struct AddLinkAddressSection: View {
+  @Binding var linkURL: String
+  
+  let onLinkURLChanged: () -> Void
+  
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("추가할 링크")
+        .font(.system(size: 12, weight: .semibold))
+        .foregroundStyle(Color.caption1)
+        .padding(.horizontal, 4)
+      
+      TextField("링크를 입력해주세요", text: $linkURL)
+        .textFieldStyle(.plain)
+        .font(.system(size: 14, weight: .medium))
+        .foregroundStyle(Color.text1)
+        .padding(16)
+        .frame(height: 56)
+        .background(Color.n0)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay {
+          RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .strokeBorder(Color.divider1, lineWidth: 1)
+        }
+        .onChange(of: linkURL) { _, _ in
+          onLinkURLChanged()
+        }
+    }
+    .frame(alignment: .top)
+  }
+}
+
+private struct AddLinkCategorySection: View {
+  let categories: [CategoryItem]
+  let totalLinkCount: Int
+  let onAddCategory: () -> Void
+  
+  @Binding var selectedCategoryID: UUID?
+  
+  private var categoryColumns: [GridItem] {
+    Array(repeating: GridItem(.flexible(minimum: 140), spacing: 10), count: 4)
+  }
+  
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      AddLinkCategoryHeader(onAddCategory: onAddCategory)
+      
+      ScrollView {
+        LazyVGrid(columns: categoryColumns, alignment: .leading, spacing: 10) {
+          AddLinkCategoryCard(
+            title: "전체",
+            countText: "\(totalLinkCount)개",
+            iconNumber: nil,
+            isSelected: selectedCategoryID == nil
+          ) {
+            selectedCategoryID = nil
+          }
+          
+          ForEach(categories) { category in
+            AddLinkCategoryCard(
+              title: category.categoryName,
+              countText: categoryCountText(category),
+              iconNumber: category.icon.number,
+              isSelected: selectedCategoryID == category.id
+            ) {
+              selectedCategoryID = category.id
+            }
+          }
+        }
+        .padding(.top, 8)
+        .padding(.bottom, 40)
+      }
+      .scrollIndicators(.hidden)
+      .overlay(alignment: .top) {
+        LinearGradient(
+          colors: [Color.background, Color.background.opacity(0)],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+        .frame(height: 12)
+        .allowsHitTesting(false)
+      }
+      .overlay(alignment: .bottom) {
+        LinearGradient(
+          colors: [Color.background.opacity(0), Color.background],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+        .frame(height: 35)
+        .allowsHitTesting(false)
+      }
+    }
+    .frame(maxHeight: .infinity, alignment: .top)
+  }
+  
+  private func categoryCountText(_ category: CategoryItem) -> String? {
+    guard let count = category.links?.count else { return nil }
+    return "\(count)개"
+  }
+}
+
+private struct AddLinkCategoryHeader: View {
+  let onAddCategory: () -> Void
+  
+  var body: some View {
+    HStack {
+      Text("카테고리 선택")
+        .font(.system(size: 12, weight: .semibold))
+        .foregroundStyle(Color.caption1)
+      
+      Spacer()
+      
+      Button(action: onAddCategory) {
+        HStack(spacing: 4) {
+          Image(icon: Icon.plus)
+            .renderingMode(.template)
+            .foregroundStyle(.bl6)
+          
+          Text("새 카테고리")
+            .font(.system(size: 12, weight: .semibold))
+        }
+        .foregroundStyle(Color.bl6)
+        .padding(.leading, 10)
+        .padding(.trailing, 16)
+        .frame(height: 34)
+        .background(Color.bl1)
+        .clipShape(Capsule())
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(.leading, 4)
+  }
+}

--- a/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkToastViews.swift
+++ b/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkToastViews.swift
@@ -1,0 +1,135 @@
+//
+//  AddLinkToastViews.swift
+//  MacAddLinkFeature
+//
+//  Created by 홍 on 05/31/26.
+//
+
+import SwiftUI
+
+import DesignSystem
+
+struct AddLinkToastLayer: View {
+  let isDuplicateLinkToastPresented: Bool
+  let statusMessage: String?
+  let isStatusError: Bool
+  let onShowExistingLink: () -> Void
+  let onCloseDuplicateToast: () -> Void
+  let onCloseStatusToast: () -> Void
+  
+  var body: some View {
+    ZStack(alignment: .top) {
+      if isDuplicateLinkToastPresented {
+        DuplicateLinkToast(
+          onShowLink: onShowExistingLink,
+          onClose: onCloseDuplicateToast
+        )
+        .frame(maxWidth: 560)
+        .padding(.horizontal, 20)
+        .padding(.top, 60)
+        .zIndex(1)
+      }
+      
+      if let statusMessage, isStatusError {
+        LinkLoadFailedToast(
+          message: statusMessage,
+          onClose: onCloseStatusToast
+        )
+        .frame(maxWidth: 560)
+        .padding(.horizontal, 20)
+        .padding(.top, 60)
+        .zIndex(1)
+      }
+    }
+  }
+}
+
+private struct LinkLoadFailedToast: View {
+  let message: String
+  let onClose: () -> Void
+  
+  var body: some View {
+    HStack(spacing: 12) {
+      Text(message)
+        .font(.system(size: 14, weight: .semibold))
+        .foregroundStyle(Color.text1)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, 8)
+        .padding(.vertical, 15)
+      
+      AddLinkToastCloseButton {
+        onClose()
+      }
+    }
+    .padding(.horizontal, 16)
+    .background {
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .fill(Color.n0)
+        .overlay {
+          RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(Color.danger.opacity(0.12))
+        }
+    }
+    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .strokeBorder(Color.danger, lineWidth: 1.5)
+    }
+    .shadow(color: Color.bgShadow5, radius: 8, x: 0, y: 0)
+    .shadow(color: Color.bgShadow5, radius: 4, x: 0, y: 2)
+  }
+}
+
+private struct DuplicateLinkToast: View {
+  let onShowLink: () -> Void
+  let onClose: () -> Void
+  
+  var body: some View {
+    HStack(spacing: 12) {
+      Text("이미 저장된 링크예요")
+        .font(.system(size: 14, weight: .semibold))
+        .foregroundStyle(Color.text1)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, 8)
+      
+      Button("보러가기") {
+        onShowLink()
+      }
+      .font(.system(size: 14, weight: .semibold))
+      .foregroundStyle(Color.bl7)
+      .padding(.horizontal, 16)
+      .frame(height: 40)
+      .buttonStyle(.plain)
+      
+      AddLinkToastCloseButton {
+        onClose()
+      }
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 8)
+    .background(Color.bl1)
+    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .strokeBorder(Color.bl6, lineWidth: 1.5)
+    }
+    .shadow(color: Color.bgShadow5, radius: 8, x: 0, y: 0)
+    .shadow(color: Color.bgShadow5, radius: 4, x: 0, y: 2)
+  }
+}
+
+private struct AddLinkToastCloseButton: View {
+  let onTap: () -> Void
+  
+  var body: some View {
+    Button(action: onTap) {
+      Image(icon: Icon.x)
+        .resizable()
+        .frame(width: 24, height: 24)
+        .foregroundStyle(Color.icon)
+        .frame(width: 40, height: 40)
+        .contentShape(RoundedRectangle(cornerRadius: 8))
+    }
+    .buttonStyle(.plain)
+  }
+}

--- a/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkView.swift
+++ b/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkView.swift
@@ -16,6 +16,7 @@ public struct AddLinkView: View {
   private let totalLinkCount: Int
   private let onSave: (ArticleItem) -> Void
   private let onShowExistingLink: () -> Void
+  private let onAddCategory: () -> Void
   
   @Environment(\.modelContext) private var modelContext
   
@@ -30,12 +31,14 @@ public struct AddLinkView: View {
     categories: [CategoryItem] = [],
     totalLinkCount: Int = 0,
     onSave: @escaping (ArticleItem) -> Void = { _ in },
-    onShowExistingLink: @escaping () -> Void = {}
+    onShowExistingLink: @escaping () -> Void = {},
+    onAddCategory: @escaping () -> Void = {}
   ) {
     self.categories = categories
     self.totalLinkCount = totalLinkCount
     self.onSave = onSave
     self.onShowExistingLink = onShowExistingLink
+    self.onAddCategory = onAddCategory
   }
   
   public var body: some View {
@@ -89,7 +92,9 @@ private extension AddLinkView {
     }
   }
   
-  func addCategoryButtonTapped() {}
+  func addCategoryButtonTapped() {
+    onAddCategory()
+  }
   
   func linkURLChanged() {
     statusMessage = nil

--- a/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkView.swift
+++ b/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkView.swift
@@ -2,7 +2,7 @@
 //  Sources.swift
 //  AddLinkFeature
 //
-//  Created by TapTap on now.
+//  Created by 홍 on 05/31/26.
 //
 
 import SwiftUI
@@ -40,32 +40,26 @@ public struct AddLinkView: View {
   
   public var body: some View {
     ZStack(alignment: .top) {
-      VStack(spacing: 20) {
-        topBar
-        
-        VStack(spacing: 24) {
-          linkAddressSection
-          categorySection
-        }
-        .frame(width: 600)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-      }
+      AddLinkMainContentView(
+        categories: categories,
+        totalLinkCount: totalLinkCount,
+        isSaving: isSaving,
+        canSubmit: canSubmit,
+        onAdd: addButtonTapped,
+        onAddCategory: addCategoryButtonTapped,
+        onLinkURLChanged: linkURLChanged,
+        linkURL: $linkURL,
+        selectedCategoryID: $selectedCategoryID
+      )
       
-      if isDuplicateLinkToastPresented {
-        DuplicateLinkToast(
-          onShowLink: {
-            isDuplicateLinkToastPresented = false
-            onShowExistingLink()
-          },
-          onClose: {
-            isDuplicateLinkToastPresented = false
-          }
-        )
-        .frame(maxWidth: 560)
-        .padding(.horizontal, 20)
-        .padding(.top, 60)
-        .zIndex(1)
-      }
+      AddLinkToastLayer(
+        isDuplicateLinkToastPresented: isDuplicateLinkToastPresented,
+        statusMessage: statusMessage,
+        isStatusError: isStatusError,
+        onShowExistingLink: showExistingLink,
+        onCloseDuplicateToast: closeDuplicateToast,
+        onCloseStatusToast: closeStatusToast
+      )
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.background)
@@ -76,170 +70,6 @@ public struct AddLinkView: View {
 }
 
 private extension AddLinkView {
-  var topBar: some View {
-    ZStack {
-      Text("링크 추가하기")
-        .font(.system(size: 16, weight: .semibold))
-        .foregroundStyle(Color.text1)
-      
-      HStack {
-        Spacer()
-        
-        Button {
-          Task {
-            await saveLink()
-          }
-        } label: {
-          HStack(spacing: 6) {
-            if isSaving {
-              ProgressView()
-                .controlSize(.small)
-                .frame(width: 15, height: 15)
-            } else {
-              Image(systemName: "plus")
-                .font(.system(size: 15, weight: .semibold))
-            }
-            
-            Text(isSaving ? "추가 중" : "추가")
-              .font(.system(size: 16, weight: .semibold))
-          }
-          .foregroundStyle(canSubmit ? Color.bl6 : Color.caption2)
-          .padding(.horizontal, 14)
-          .padding(.vertical, 9)
-          .background(canSubmit ? Color.bl1 : Color.n40)
-          .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .disabled(!canSubmit)
-      }
-      .padding(.trailing, 32)
-    }
-    .padding(.bottom, 20)
-    .frame(maxWidth: .infinity)
-    .background(Color.n0)
-    .overlay(alignment: .bottom) {
-      Rectangle()
-        .fill(Color.divider1)
-        .frame(height: 1)
-    }
-  }
-  
-  var linkAddressSection: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      Text("추가할 링크")
-        .font(.system(size: 12, weight: .semibold))
-        .foregroundStyle(Color.caption1)
-        .padding(.horizontal, 4)
-      
-      TextField("링크를 입력해주세요", text: $linkURL)
-        .textFieldStyle(.plain)
-        .font(.system(size: 14, weight: .medium))
-        .foregroundStyle(Color.text1)
-        .padding(16)
-        .frame(height: 56)
-        .background(Color.n0)
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay {
-          RoundedRectangle(cornerRadius: 12, style: .continuous)
-            .strokeBorder(Color.divider1, lineWidth: 1)
-        }
-        .onChange(of: linkURL) { _, _ in
-          statusMessage = nil
-          isDuplicateLinkToastPresented = false
-        }
-      
-      if let statusMessage {
-        Text(statusMessage)
-          .font(.system(size: 12, weight: .medium))
-          .foregroundStyle(isStatusError ? Color.danger : Color.caption1)
-          .padding(.horizontal, 4)
-      }
-    }
-    .frame(alignment: .top)
-  }
-  
-  var categorySection: some View {
-    VStack(alignment: .leading, spacing: 0) {
-      HStack {
-        Text("카테고리 선택")
-          .font(.system(size: 12, weight: .semibold))
-          .foregroundStyle(Color.caption1)
-        
-        Spacer()
-        
-        Button {
-        } label: {
-          HStack(spacing: 4) {
-            Image(icon: Icon.plus)
-              .renderingMode(.template)
-              .foregroundStyle(.bl6)
-            
-            Text("새 카테고리")
-              .font(.system(size: 12, weight: .semibold))
-          }
-          .foregroundStyle(Color.bl6)
-          .padding(.leading, 10)
-          .padding(.trailing, 16)
-          .frame(height: 34)
-          .background(Color.bl1)
-          .clipShape(Capsule())
-        }
-        .buttonStyle(.plain)
-      }
-      .padding(.leading, 4)
-      
-      ScrollView {
-        LazyVGrid(columns: categoryColumns, alignment: .leading, spacing: 10) {
-          CategoryCard(
-            title: "전체",
-            countText: "\(totalLinkCount)개",
-            iconNumber: nil,
-            isSelected: selectedCategoryID == nil
-          ) {
-            selectedCategoryID = nil
-          }
-          
-          ForEach(categories) { category in
-            CategoryCard(
-              title: category.categoryName,
-              countText: categoryCountText(category),
-              iconNumber: category.icon.number,
-              isSelected: selectedCategoryID == category.id
-            ) {
-              selectedCategoryID = category.id
-            }
-          }
-        }
-        .padding(.top, 8)
-        .padding(.bottom, 40)
-      }
-      .scrollIndicators(.hidden)
-      .overlay(alignment: .top) {
-        LinearGradient(
-          colors: [Color.background, Color.background.opacity(0)],
-          startPoint: .top,
-          endPoint: .bottom
-        )
-        .frame(height: 12)
-        .allowsHitTesting(false)
-      }
-      .overlay(alignment: .bottom) {
-        LinearGradient(
-          colors: [Color.background.opacity(0), Color.background],
-          startPoint: .top,
-          endPoint: .bottom
-        )
-        .frame(height: 35)
-        .allowsHitTesting(false)
-      }
-    }
-    .frame(maxHeight: .infinity, alignment: .top)
-  }
-  
-  var categoryColumns: [GridItem] {
-    Array(repeating: GridItem(.flexible(minimum: 140), spacing: 10), count: 4)
-  }
-  
   var isAddButtonEnabled: Bool {
     !linkURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
   }
@@ -248,14 +78,35 @@ private extension AddLinkView {
     isAddButtonEnabled && !isSaving && !isDuplicateLinkToastPresented
   }
   
-  func categoryCountText(_ category: CategoryItem) -> String? {
-    guard let count = category.links?.count else { return nil }
-    return "\(count)개"
-  }
-  
   func selectedCategory() -> CategoryItem? {
     guard let selectedCategoryID else { return nil }
     return categories.first { $0.id == selectedCategoryID }
+  }
+  
+  func addButtonTapped() {
+    Task {
+      await saveLink()
+    }
+  }
+  
+  func addCategoryButtonTapped() {}
+  
+  func linkURLChanged() {
+    statusMessage = nil
+    isDuplicateLinkToastPresented = false
+  }
+  
+  func showExistingLink() {
+    isDuplicateLinkToastPresented = false
+    onShowExistingLink()
+  }
+  
+  func closeDuplicateToast() {
+    isDuplicateLinkToastPresented = false
+  }
+  
+  func closeStatusToast() {
+    statusMessage = nil
   }
   
   @MainActor
@@ -296,22 +147,24 @@ private extension AddLinkView {
       }
       
       let metadata = try await LinkService.shared.extractMetadata(from: url)
+      let selectedCategory = selectedCategory()
       let article = ArticleItem(
         urlString: normalizedURLString,
         title: metadata.title,
         imageURL: metadata.imageURL?.absoluteString
       )
-      article.category = selectedCategory()
+      article.category = selectedCategory
       
       modelContext.insert(article)
       try modelContext.save()
       
       linkURL = ""
       selectedCategoryID = nil
-      showStatus("링크를 추가했어요", isError: false)
+      statusMessage = nil
+      isDuplicateLinkToastPresented = false
       onSave(article)
     } catch {
-      showStatus("링크 추가에 실패했어요", isError: true)
+      showStatus("링크를 불러올 수 없어요", isError: true)
     }
   }
   
@@ -334,101 +187,9 @@ private extension AddLinkView {
   func showStatus(_ message: String, isError: Bool) {
     statusMessage = message
     isStatusError = isError
-  }
-}
-
-private struct DuplicateLinkToast: View {
-  let onShowLink: () -> Void
-  let onClose: () -> Void
-  
-  var body: some View {
-    HStack(spacing: 12) {
-      Text("이미 저장된 링크예요")
-        .font(.system(size: 14, weight: .semibold))
-        .foregroundStyle(Color.text1)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.leading, 8)
-      
-      Button("보러가기") {
-        onShowLink()
-      }
-      .font(.system(size: 14, weight: .semibold))
-      .foregroundStyle(Color.bl7)
-      .padding(.horizontal, 16)
-      .frame(height: 40)
-      .buttonStyle(.plain)
-      
-      MacToastCloseButton {
-        onClose()
-      }
-    }
-    .padding(.horizontal, 16)
-    .padding(.vertical, 8)
-    .background(Color.bl1)
-    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-    .overlay {
-      RoundedRectangle(cornerRadius: 12, style: .continuous)
-        .strokeBorder(Color.bl6, lineWidth: 1.5)
-    }
-    .shadow(color: Color.bgShadow5, radius: 8, x: 0, y: 0)
-    .shadow(color: Color.bgShadow5, radius: 4, x: 0, y: 2)
-  }
-}
-
-private struct CategoryCard: View {
-  let title: String
-  let countText: String?
-  let iconNumber: Int?
-  let isSelected: Bool
-  let action: () -> Void
-  
-  @State private var isHovered: Bool = false
-  
-  var body: some View {
-    Button(action: action) {
-      ZStack(alignment: .bottomTrailing) {
-        VStack(alignment: .leading, spacing: 4) {
-          Text(title)
-            .font(.system(size: 14, weight: .semibold))
-            .foregroundStyle(Color.text1)
-            .lineLimit(2)
-            .frame(maxWidth: .infinity, alignment: .leading)
-          
-          Text(countText ?? "0개")
-            .font(.system(size: 12, weight: .medium))
-            .foregroundStyle(isSelected ? Color.caption1 : Color.caption2)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        
-        categoryIcon
-          .frame(width: 56, height: 56)
-          .offset(x: 2, y: 2)
-      }
-      .padding(16)
-      .frame(height: 116)
-      .frame(minWidth: 140, maxWidth: .infinity)
-      .background(isSelected || isHovered ? Color.bl1 : Color.n0)
-      .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-      .overlay {
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-          .strokeBorder(isSelected ? Color.bl6 : .clear, lineWidth: 1.5)
-      }
-      .shadow(color: Color.bgShadow3, radius: 8, x: 0, y: 0)
-    }
-    .buttonStyle(.plain)
-    .onHover { isHovered = $0 }
-  }
-  
-  @ViewBuilder
-  private var categoryIcon: some View {
-    if let iconNumber {
-      DesignSystemAsset.primaryCategoryIcon(number: iconNumber)
-        .resizable()
-        .scaledToFit()
-    } else {
-      DesignSystemAsset.primaryCategoryIcon(number: 1)
-        .resizable()
-        .scaledToFit()
+    
+    if isError {
+      isDuplicateLinkToastPresented = false
     }
   }
 }

--- a/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkView.swift
+++ b/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkView.swift
@@ -7,10 +7,249 @@
 
 import SwiftUI
 
+import Core
+import DesignSystem
+
 public struct AddLinkView: View {
-  public init() {}
+  private let categories: [CategoryItem]
+  private let totalLinkCount: Int
+  
+  @State private var linkURL: String = ""
+  @State private var selectedCategoryID: UUID?
+  
+  public init(
+    categories: [CategoryItem] = [],
+    totalLinkCount: Int = 0
+  ) {
+    self.categories = categories
+    self.totalLinkCount = totalLinkCount
+  }
   
   public var body: some View {
-    Text("AddLinkView")
+    VStack(spacing: 20) {
+      topBar
+      
+      VStack(spacing: 24) {
+        linkAddressSection
+        categorySection
+      }
+      .frame(width: 600)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.background)
+  }
+}
+
+private extension AddLinkView {
+  var topBar: some View {
+    ZStack {
+      Text("링크 추가하기")
+        .font(.system(size: 16, weight: .semibold))
+        .foregroundStyle(Color.text1)
+      
+      HStack {
+        Spacer()
+        
+        Button {
+        } label: {
+          HStack(spacing: 6) {
+            Image(systemName: "plus")
+              .font(.system(size: 15, weight: .semibold))
+            
+            Text("추가")
+              .font(.system(size: 16, weight: .semibold))
+          }
+          .foregroundStyle(isAddButtonEnabled ? Color.bl6 : Color.caption2)
+          .padding(.horizontal, 14)
+          .padding(.vertical, 9)
+          .background(isAddButtonEnabled ? Color.bl1 : Color.n40)
+          .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .disabled(!isAddButtonEnabled)
+      }
+      .padding(.trailing, 32)
+    }
+    .padding(.bottom, 20)
+    .frame(maxWidth: .infinity)
+    .background(Color.n0)
+    .overlay(alignment: .bottom) {
+      Rectangle()
+        .fill(Color.divider1)
+        .frame(height: 1)
+    }
+  }
+  
+  var linkAddressSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("추가할 링크")
+        .font(.system(size: 12, weight: .semibold))
+        .foregroundStyle(Color.caption1)
+        .padding(.horizontal, 4)
+      
+      TextField("링크를 입력해주세요", text: $linkURL)
+        .textFieldStyle(.plain)
+        .font(.system(size: 14, weight: .medium))
+        .foregroundStyle(Color.text1)
+        .padding(16)
+        .frame(height: 56)
+        .background(Color.n0)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay {
+          RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .strokeBorder(Color.divider1, lineWidth: 1)
+        }
+    }
+    .frame(height: 85, alignment: .top)
+  }
+  
+  var categorySection: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack {
+        Text("카테고리 선택")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(Color.caption1)
+        
+        Spacer()
+        
+        Button {
+        } label: {
+          HStack(spacing: 4) {
+            Image(icon: Icon.plus)
+              .renderingMode(.template)
+              .foregroundStyle(.bl6)
+            
+            Text("새 카테고리")
+              .font(.system(size: 12, weight: .semibold))
+          }
+          .foregroundStyle(Color.bl6)
+          .padding(.leading, 10)
+          .padding(.trailing, 16)
+          .frame(height: 34)
+          .background(Color.bl1)
+          .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+      }
+      .padding(.leading, 4)
+      
+      ScrollView {
+        LazyVGrid(columns: categoryColumns, alignment: .leading, spacing: 10) {
+          CategoryCard(
+            title: "전체",
+            countText: "\(totalLinkCount)개",
+            iconNumber: nil,
+            isSelected: selectedCategoryID == nil
+          ) {
+            selectedCategoryID = nil
+          }
+          
+          ForEach(categories) { category in
+            CategoryCard(
+              title: category.categoryName,
+              countText: categoryCountText(category),
+              iconNumber: category.icon.number,
+              isSelected: selectedCategoryID == category.id
+            ) {
+              selectedCategoryID = category.id
+            }
+          }
+        }
+        .padding(.top, 8)
+        .padding(.bottom, 40)
+      }
+      .scrollIndicators(.hidden)
+      .overlay(alignment: .top) {
+        LinearGradient(
+          colors: [Color.background, Color.background.opacity(0)],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+        .frame(height: 12)
+        .allowsHitTesting(false)
+      }
+      .overlay(alignment: .bottom) {
+        LinearGradient(
+          colors: [Color.background.opacity(0), Color.background],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+        .frame(height: 35)
+        .allowsHitTesting(false)
+      }
+    }
+    .frame(maxHeight: .infinity, alignment: .top)
+  }
+  
+  var categoryColumns: [GridItem] {
+    Array(repeating: GridItem(.flexible(minimum: 140), spacing: 10), count: 4)
+  }
+  
+  var isAddButtonEnabled: Bool {
+    !linkURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+  
+  func categoryCountText(_ category: CategoryItem) -> String? {
+    guard let count = category.links?.count else { return nil }
+    return "\(count)개"
+  }
+}
+
+private struct CategoryCard: View {
+  let title: String
+  let countText: String?
+  let iconNumber: Int?
+  let isSelected: Bool
+  let action: () -> Void
+  
+  @State private var isHovered: Bool = false
+  
+  var body: some View {
+    Button(action: action) {
+      ZStack(alignment: .bottomTrailing) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text(title)
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(Color.text1)
+            .lineLimit(2)
+            .frame(maxWidth: .infinity, alignment: .leading)
+          
+          Text(countText ?? "0개")
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(isSelected ? Color.caption1 : Color.caption2)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        
+        categoryIcon
+          .frame(width: 56, height: 56)
+          .offset(x: 2, y: 2)
+      }
+      .padding(16)
+      .frame(height: 116)
+      .frame(minWidth: 140, maxWidth: .infinity)
+      .background(isSelected || isHovered ? Color.bl1 : Color.n0)
+      .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+      .overlay {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .strokeBorder(isSelected ? Color.bl6 : .clear, lineWidth: 1.5)
+      }
+      .shadow(color: Color.bgShadow3, radius: 8, x: 0, y: 0)
+    }
+    .buttonStyle(.plain)
+    .onHover { isHovered = $0 }
+  }
+  
+  @ViewBuilder
+  private var categoryIcon: some View {
+    if let iconNumber {
+      DesignSystemAsset.primaryCategoryIcon(number: iconNumber)
+        .resizable()
+        .scaledToFit()
+    } else {
+      DesignSystemAsset.primaryCategoryIcon(number: 1)
+        .resizable()
+        .scaledToFit()
+    }
   }
 }

--- a/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkView.swift
+++ b/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkView.swift
@@ -15,6 +15,7 @@ public struct AddLinkView: View {
   private let categories: [CategoryItem]
   private let totalLinkCount: Int
   private let onSave: (ArticleItem) -> Void
+  private let onShowExistingLink: () -> Void
   
   @Environment(\.modelContext) private var modelContext
   
@@ -23,30 +24,54 @@ public struct AddLinkView: View {
   @State private var isSaving: Bool = false
   @State private var statusMessage: String?
   @State private var isStatusError: Bool = false
+  @State private var isDuplicateLinkToastPresented: Bool = false
   
   public init(
     categories: [CategoryItem] = [],
     totalLinkCount: Int = 0,
-    onSave: @escaping (ArticleItem) -> Void = { _ in }
+    onSave: @escaping (ArticleItem) -> Void = { _ in },
+    onShowExistingLink: @escaping () -> Void = {}
   ) {
     self.categories = categories
     self.totalLinkCount = totalLinkCount
     self.onSave = onSave
+    self.onShowExistingLink = onShowExistingLink
   }
   
   public var body: some View {
-    VStack(spacing: 20) {
-      topBar
-      
-      VStack(spacing: 24) {
-        linkAddressSection
-        categorySection
+    ZStack(alignment: .top) {
+      VStack(spacing: 20) {
+        topBar
+        
+        VStack(spacing: 24) {
+          linkAddressSection
+          categorySection
+        }
+        .frame(width: 600)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
       }
-      .frame(width: 600)
-      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+      
+      if isDuplicateLinkToastPresented {
+        DuplicateLinkToast(
+          onShowLink: {
+            isDuplicateLinkToastPresented = false
+            onShowExistingLink()
+          },
+          onClose: {
+            isDuplicateLinkToastPresented = false
+          }
+        )
+        .frame(maxWidth: 560)
+        .padding(.horizontal, 20)
+        .padding(.top, 60)
+        .zIndex(1)
+      }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.background)
+    .task(id: linkURL) {
+      await checkDuplicateLink(for: linkURL)
+    }
   }
 }
 
@@ -120,6 +145,7 @@ private extension AddLinkView {
         }
         .onChange(of: linkURL) { _, _ in
           statusMessage = nil
+          isDuplicateLinkToastPresented = false
         }
       
       if let statusMessage {
@@ -219,7 +245,7 @@ private extension AddLinkView {
   }
   
   var canSubmit: Bool {
-    isAddButtonEnabled && !isSaving
+    isAddButtonEnabled && !isSaving && !isDuplicateLinkToastPresented
   }
   
   func categoryCountText(_ category: CategoryItem) -> String? {
@@ -233,10 +259,28 @@ private extension AddLinkView {
   }
   
   @MainActor
+  func checkDuplicateLink(for rawURLString: String) async {
+    try? await Task.sleep(nanoseconds: 300_000_000)
+    guard !Task.isCancelled else { return }
+    
+    let normalizedURLString = normalizedURLString(from: rawURLString)
+    guard isValidURLString(normalizedURLString) else {
+      isDuplicateLinkToastPresented = false
+      return
+    }
+    
+    do {
+      isDuplicateLinkToastPresented = try LinkService.shared.urlExists(normalizedURLString)
+    } catch {
+      isDuplicateLinkToastPresented = false
+    }
+  }
+  
+  @MainActor
   func saveLink() async {
     let normalizedURLString = normalizedURLString(from: linkURL)
     
-    guard let url = URL(string: normalizedURLString), url.scheme != nil, url.host != nil else {
+    guard isValidURLString(normalizedURLString), let url = URL(string: normalizedURLString) else {
       showStatus("올바른 링크를 입력해주세요", isError: true)
       return
     }
@@ -246,7 +290,8 @@ private extension AddLinkView {
     
     do {
       if try LinkService.shared.urlExists(normalizedURLString) {
-        showStatus("이미 저장된 링크입니다", isError: true)
+        statusMessage = nil
+        isDuplicateLinkToastPresented = true
         return
       }
       
@@ -281,9 +326,52 @@ private extension AddLinkView {
     return "https://\(trimmedValue)"
   }
   
+  func isValidURLString(_ urlString: String) -> Bool {
+    guard let url = URL(string: urlString) else { return false }
+    return url.scheme != nil && url.host != nil
+  }
+  
   func showStatus(_ message: String, isError: Bool) {
     statusMessage = message
     isStatusError = isError
+  }
+}
+
+private struct DuplicateLinkToast: View {
+  let onShowLink: () -> Void
+  let onClose: () -> Void
+  
+  var body: some View {
+    HStack(spacing: 12) {
+      Text("이미 저장된 링크예요")
+        .font(.system(size: 14, weight: .semibold))
+        .foregroundStyle(Color.text1)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, 8)
+      
+      Button("보러가기") {
+        onShowLink()
+      }
+      .font(.system(size: 14, weight: .semibold))
+      .foregroundStyle(Color.bl7)
+      .padding(.horizontal, 16)
+      .frame(height: 40)
+      .buttonStyle(.plain)
+      
+      MacToastCloseButton {
+        onClose()
+      }
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 8)
+    .background(Color.bl1)
+    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .strokeBorder(Color.bl6, lineWidth: 1.5)
+    }
+    .shadow(color: Color.bgShadow5, radius: 8, x: 0, y: 0)
+    .shadow(color: Color.bgShadow5, radius: 4, x: 0, y: 2)
   }
 }
 

--- a/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkView.swift
+++ b/TapTap/Projects/MacFeature/AddLinkFeature/Sources/AddLinkView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import SwiftData
 
 import Core
 import DesignSystem
@@ -13,16 +14,24 @@ import DesignSystem
 public struct AddLinkView: View {
   private let categories: [CategoryItem]
   private let totalLinkCount: Int
+  private let onSave: (ArticleItem) -> Void
+  
+  @Environment(\.modelContext) private var modelContext
   
   @State private var linkURL: String = ""
   @State private var selectedCategoryID: UUID?
+  @State private var isSaving: Bool = false
+  @State private var statusMessage: String?
+  @State private var isStatusError: Bool = false
   
   public init(
     categories: [CategoryItem] = [],
-    totalLinkCount: Int = 0
+    totalLinkCount: Int = 0,
+    onSave: @escaping (ArticleItem) -> Void = { _ in }
   ) {
     self.categories = categories
     self.totalLinkCount = totalLinkCount
+    self.onSave = onSave
   }
   
   public var body: some View {
@@ -52,22 +61,31 @@ private extension AddLinkView {
         Spacer()
         
         Button {
+          Task {
+            await saveLink()
+          }
         } label: {
           HStack(spacing: 6) {
-            Image(systemName: "plus")
-              .font(.system(size: 15, weight: .semibold))
+            if isSaving {
+              ProgressView()
+                .controlSize(.small)
+                .frame(width: 15, height: 15)
+            } else {
+              Image(systemName: "plus")
+                .font(.system(size: 15, weight: .semibold))
+            }
             
-            Text("추가")
+            Text(isSaving ? "추가 중" : "추가")
               .font(.system(size: 16, weight: .semibold))
           }
-          .foregroundStyle(isAddButtonEnabled ? Color.bl6 : Color.caption2)
+          .foregroundStyle(canSubmit ? Color.bl6 : Color.caption2)
           .padding(.horizontal, 14)
           .padding(.vertical, 9)
-          .background(isAddButtonEnabled ? Color.bl1 : Color.n40)
+          .background(canSubmit ? Color.bl1 : Color.n40)
           .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         }
         .buttonStyle(.plain)
-        .disabled(!isAddButtonEnabled)
+        .disabled(!canSubmit)
       }
       .padding(.trailing, 32)
     }
@@ -100,8 +118,18 @@ private extension AddLinkView {
           RoundedRectangle(cornerRadius: 12, style: .continuous)
             .strokeBorder(Color.divider1, lineWidth: 1)
         }
+        .onChange(of: linkURL) { _, _ in
+          statusMessage = nil
+        }
+      
+      if let statusMessage {
+        Text(statusMessage)
+          .font(.system(size: 12, weight: .medium))
+          .foregroundStyle(isStatusError ? Color.danger : Color.caption1)
+          .padding(.horizontal, 4)
+      }
     }
-    .frame(height: 85, alignment: .top)
+    .frame(alignment: .top)
   }
   
   var categorySection: some View {
@@ -190,9 +218,72 @@ private extension AddLinkView {
     !linkURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
   }
   
+  var canSubmit: Bool {
+    isAddButtonEnabled && !isSaving
+  }
+  
   func categoryCountText(_ category: CategoryItem) -> String? {
     guard let count = category.links?.count else { return nil }
     return "\(count)개"
+  }
+  
+  func selectedCategory() -> CategoryItem? {
+    guard let selectedCategoryID else { return nil }
+    return categories.first { $0.id == selectedCategoryID }
+  }
+  
+  @MainActor
+  func saveLink() async {
+    let normalizedURLString = normalizedURLString(from: linkURL)
+    
+    guard let url = URL(string: normalizedURLString), url.scheme != nil, url.host != nil else {
+      showStatus("올바른 링크를 입력해주세요", isError: true)
+      return
+    }
+    
+    isSaving = true
+    defer { isSaving = false }
+    
+    do {
+      if try LinkService.shared.urlExists(normalizedURLString) {
+        showStatus("이미 저장된 링크입니다", isError: true)
+        return
+      }
+      
+      let metadata = try await LinkService.shared.extractMetadata(from: url)
+      let article = ArticleItem(
+        urlString: normalizedURLString,
+        title: metadata.title,
+        imageURL: metadata.imageURL?.absoluteString
+      )
+      article.category = selectedCategory()
+      
+      modelContext.insert(article)
+      try modelContext.save()
+      
+      linkURL = ""
+      selectedCategoryID = nil
+      showStatus("링크를 추가했어요", isError: false)
+      onSave(article)
+    } catch {
+      showStatus("링크 추가에 실패했어요", isError: true)
+    }
+  }
+  
+  func normalizedURLString(from rawValue: String) -> String {
+    let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedValue.isEmpty else { return trimmedValue }
+    
+    if trimmedValue.contains("://") {
+      return trimmedValue
+    }
+    
+    return "https://\(trimmedValue)"
+  }
+  
+  func showStatus(_ message: String, isError: Bool) {
+    statusMessage = message
+    isStatusError = isError
   }
 }
 

--- a/TapTap/Projects/Shared/Sources/Dependency/SwiftData/Repository/CategoryRepository.swift
+++ b/TapTap/Projects/Shared/Sources/Dependency/SwiftData/Repository/CategoryRepository.swift
@@ -50,9 +50,17 @@ public struct CategoryRepository {
       }
   }
   
+  public func toggleFavorite(id: UUID) throws {
+    try CategoryCommand(context: context).toggleFavorite(id: id)
+  }
+  
   // MARK: - Delete
   public func deleteCategory(_ category: CategoryItem) throws {
     context.delete(category)
     try context.save()
+  }
+  
+  public func deleteCategory(id: UUID) throws {
+    try CategoryCommand(context: context).deleteCategory(id: id)
   }
 }

--- a/TapTap/Projects/TapTapMac/Sources/RootView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/RootView.swift
@@ -26,6 +26,8 @@ struct RootView: View {
   @State private var selectedCategoryID: UUID?
   @State private var isLinkListEditing: Bool = false
   @State private var selectedDetail: DetailDestination = .linkList
+  @State private var isSaveSuccessToastPresented: Bool = false
+  @State private var saveSuccessCategoryName: String = "전체"
   
   @ObservedObject var searchViewModel: SearchViewModel
   @State private var isSearchOverlayPresented: Bool = false
@@ -43,6 +45,7 @@ struct RootView: View {
         onAddLink: {
           isLinkListEditing = false
           isSearchOverlayPresented = false
+          isSaveSuccessToastPresented = false
           searchViewModel.clearSearch()
           isSeeAllSelected = false
           selectedCategoryID = nil
@@ -50,6 +53,7 @@ struct RootView: View {
         },
         onSeeAllLinks: {
           selectedDetail = .linkList
+          isSaveSuccessToastPresented = false
           isSeeAllSelected = true
           selectedCategoryID = nil
           searchViewModel.clearSearch()
@@ -57,6 +61,7 @@ struct RootView: View {
         onAddCategory: { },
         onSelectCategory: { category in
           selectedDetail = .linkList
+          isSaveSuccessToastPresented = false
           isSeeAllSelected = false
           selectedCategoryID = category.id
           searchViewModel.clearSearch()
@@ -104,6 +109,19 @@ struct RootView: View {
           )
           .zIndex(10)
         }
+        
+        if isSaveSuccessToastPresented {
+          SaveSuccessToast(
+            categoryName: saveSuccessCategoryName,
+            onClose: {
+              isSaveSuccessToastPresented = false
+            }
+          )
+          .frame(maxWidth: 560)
+          .padding(.horizontal, 20)
+          .padding(.top, 60)
+          .zIndex(20)
+        }
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
       .background(Color.background)
@@ -144,10 +162,8 @@ struct RootView: View {
         AddLinkView(
           categories: allCategories,
           totalLinkCount: articles.count,
-          onSave: { _ in
-            selectedDetail = .linkList
-            isSeeAllSelected = true
-            selectedCategoryID = nil
+          onSave: { article in
+            showSavedLink(article)
           },
           onShowExistingLink: {
             selectedDetail = .linkList
@@ -159,9 +175,79 @@ struct RootView: View {
       }
     }
   }
+  
+  private func showSavedLink(_ article: ArticleItem) {
+    selectedDetail = .linkList
+    isLinkListEditing = false
+    isSearchOverlayPresented = false
+    searchViewModel.clearSearch()
+    
+    if let category = article.category {
+      isSeeAllSelected = false
+      selectedCategoryID = category.id
+      saveSuccessCategoryName = category.categoryName
+    } else {
+      isSeeAllSelected = true
+      selectedCategoryID = nil
+      saveSuccessCategoryName = "전체"
+    }
+    
+    isSaveSuccessToastPresented = true
+  }
 }
 
 private enum DetailDestination: Equatable {
   case linkList
   case addLink
+}
+
+private struct SaveSuccessToast: View {
+  let categoryName: String
+  let onClose: () -> Void
+  
+  var body: some View {
+    HStack(spacing: 12) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text("링크를 저장했어요!")
+          .font(.system(size: 14, weight: .semibold))
+          .foregroundStyle(Color.text1)
+        
+        Text("\(categoryName)에서 확인할 수 있어요")
+          .font(.system(size: 12, weight: .medium))
+          .foregroundStyle(Color.caption1)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.leading, 8)
+      .padding(.vertical, 15)
+      
+      ToastCloseButtonWithoutHover {
+        onClose()
+      }
+    }
+    .padding(.horizontal, 16)
+    .background(Color.bl1)
+    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .strokeBorder(Color.bl6, lineWidth: 1.5)
+    }
+    .shadow(color: Color.bgShadow5, radius: 8, x: 0, y: 0)
+    .shadow(color: Color.bgShadow5, radius: 4, x: 0, y: 2)
+  }
+}
+
+private struct ToastCloseButtonWithoutHover: View {
+  let onTap: () -> Void
+  
+  var body: some View {
+    Button(action: onTap) {
+      Image(icon: Icon.x)
+        .resizable()
+        .frame(width: 24, height: 24)
+        .foregroundStyle(Color.icon)
+        .frame(width: 40, height: 40)
+        .contentShape(RoundedRectangle(cornerRadius: 8))
+    }
+    .buttonStyle(.plain)
+  }
 }

--- a/TapTap/Projects/TapTapMac/Sources/RootView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/RootView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import Core
 import DesignSystem
 
+import MacAddLinkFeature
 import MacHomeFeature
 import MacLinkListFeature
 import MacSearchFeature
@@ -24,6 +25,7 @@ struct RootView: View {
   @State private var isSeeAllSelected: Bool = true
   @State private var selectedCategoryID: UUID?
   @State private var isLinkListEditing: Bool = false
+  @State private var selectedDetail: DetailDestination = .linkList
   
   @ObservedObject var searchViewModel: SearchViewModel
   @State private var isSearchOverlayPresented: Bool = false
@@ -38,14 +40,23 @@ struct RootView: View {
         selectedCategoryID: selectedCategoryID,
         isCollapsed: isSidebarCollapsed,
         onToggleSidebar: { withAnimation(.easeInOut(duration: 0.2)) { isSidebarCollapsed.toggle() } },
-        onAddLink: { },
+        onAddLink: {
+          isLinkListEditing = false
+          isSearchOverlayPresented = false
+          searchViewModel.clearSearch()
+          isSeeAllSelected = false
+          selectedCategoryID = nil
+          selectedDetail = .addLink
+        },
         onSeeAllLinks: {
+          selectedDetail = .linkList
           isSeeAllSelected = true
           selectedCategoryID = nil
           searchViewModel.clearSearch()
         },
         onAddCategory: { },
         onSelectCategory: { category in
+          selectedDetail = .linkList
           isSeeAllSelected = false
           selectedCategoryID = category.id
           searchViewModel.clearSearch()
@@ -56,7 +67,7 @@ struct RootView: View {
       
       ZStack(alignment: .top) {
         VStack(spacing: 0) {
-          if !isLinkListEditing {
+          if selectedDetail == .linkList, !isLinkListEditing {
             MacToolbar(
               text: $searchViewModel.query,
               onSearchTap: {
@@ -65,8 +76,8 @@ struct RootView: View {
               }
             )
           }
-          
-          if searchViewModel.hasSubmittedSearch {
+
+          if selectedDetail == .linkList, searchViewModel.hasSubmittedSearch {
             SearchView(viewModel: searchViewModel) { item in
               item.lastViewedDate = Date()
               try? modelContext.save()
@@ -76,7 +87,7 @@ struct RootView: View {
             detailContent
           }
         }
-        
+
         if isSearchOverlayPresented {
           Color.black.opacity(0.16)
             .ignoresSafeArea()
@@ -115,15 +126,32 @@ struct RootView: View {
   }
   
   private var detailContent: some View {
-    LinkListContainerView(
-      articles: articles,
-      categories: allCategories,
-      selectedCategoryID: selectedCategoryID,
-      isSeeAllSelected: isSeeAllSelected,
-      isEditing: $isLinkListEditing,
-      onArticleTap: { article in
-        print(article.title)
+    Group {
+      switch selectedDetail {
+      case .linkList:
+        LinkListContainerView(
+          articles: articles,
+          categories: allCategories,
+          selectedCategoryID: selectedCategoryID,
+          isSeeAllSelected: isSeeAllSelected,
+          isEditing: $isLinkListEditing,
+          onArticleTap: { article in
+            print(article.title)
+          }
+        )
+
+      case .addLink:
+        AddLinkView(
+          categories: allCategories,
+          totalLinkCount: articles.count
+        )
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
       }
-    )
+    }
   }
+}
+
+private enum DetailDestination: Equatable {
+  case linkList
+  case addLink
 }

--- a/TapTap/Projects/TapTapMac/Sources/RootView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/RootView.swift
@@ -34,41 +34,44 @@ struct RootView: View {
   
   var body: some View {
     HStack(spacing: 0) {
-      MacSidebarView(
-        totalLinkCount: articles.count,
-        favoriteCategories: favoriteCategories,
-        categories: categoriesForList,
-        isSeeAllSelected: isSeeAllSelected,
-        selectedCategoryID: selectedCategoryID,
-        isCollapsed: isSidebarCollapsed,
-        onToggleSidebar: { withAnimation(.easeInOut(duration: 0.2)) { isSidebarCollapsed.toggle() } },
-        onAddLink: {
-          isLinkListEditing = false
-          isSearchOverlayPresented = false
-          isSaveSuccessToastPresented = false
-          searchViewModel.clearSearch()
-          isSeeAllSelected = false
-          selectedCategoryID = nil
-          selectedDetail = .addLink
-        },
-        onSeeAllLinks: {
-          selectedDetail = .linkList
-          isSaveSuccessToastPresented = false
-          isSeeAllSelected = true
-          selectedCategoryID = nil
-          searchViewModel.clearSearch()
-        },
-        onAddCategory: { },
-        onSelectCategory: { category in
-          selectedDetail = .linkList
-          isSaveSuccessToastPresented = false
-          isSeeAllSelected = false
-          selectedCategoryID = category.id
-          searchViewModel.clearSearch()
-        },
-        onSettings: { }
-      )
-      .zIndex(1)
+      if !isSidebarCollapsed {
+        MacSidebarView(
+          totalLinkCount: articles.count,
+          favoriteCategories: favoriteCategories,
+          categories: categoriesForList,
+          isSeeAllSelected: isSeeAllSelected,
+          selectedCategoryID: selectedCategoryID,
+          isCollapsed: isSidebarCollapsed,
+          onToggleSidebar: toggleSidebar,
+          onAddLink: {
+            isLinkListEditing = false
+            isSearchOverlayPresented = false
+            isSaveSuccessToastPresented = false
+            searchViewModel.clearSearch()
+            isSeeAllSelected = false
+            selectedCategoryID = nil
+            selectedDetail = .addLink
+          },
+          onSeeAllLinks: {
+            selectedDetail = .linkList
+            isSaveSuccessToastPresented = false
+            isSeeAllSelected = true
+            selectedCategoryID = nil
+            searchViewModel.clearSearch()
+          },
+          onAddCategory: { },
+          onSelectCategory: { category in
+            selectedDetail = .linkList
+            isSaveSuccessToastPresented = false
+            isSeeAllSelected = false
+            selectedCategoryID = category.id
+            searchViewModel.clearSearch()
+          },
+          onSettings: { }
+        )
+        .transition(.move(edge: .leading).combined(with: .opacity))
+        .zIndex(1)
+      }
       
       ZStack(alignment: .top) {
         VStack(spacing: 0) {
@@ -126,12 +129,28 @@ struct RootView: View {
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
       .background(Color.background)
     }
+    .overlay(alignment: .topLeading) {
+      if isSidebarCollapsed {
+        Button(action: toggleSidebar) {
+          SidebarToggleIcon(isCollapsed: true)
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 16)
+        .padding(.leading, 16)
+      }
+    }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .onAppear {
       searchViewModel.updateArticles(articles)
     }
     .onChange(of: articles) { _, newValue in
       searchViewModel.updateArticles(newValue)
+    }
+  }
+
+  private func toggleSidebar() {
+    withAnimation(.easeInOut(duration: 0.2)) {
+      isSidebarCollapsed.toggle()
     }
   }
   

--- a/TapTap/Projects/TapTapMac/Sources/RootView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/RootView.swift
@@ -143,7 +143,12 @@ struct RootView: View {
       case .addLink:
         AddLinkView(
           categories: allCategories,
-          totalLinkCount: articles.count
+          totalLinkCount: articles.count,
+          onSave: { _ in
+            selectedDetail = .linkList
+            isSeeAllSelected = true
+            selectedCategoryID = nil
+          }
         )
           .frame(maxWidth: .infinity, maxHeight: .infinity)
       }

--- a/TapTap/Projects/TapTapMac/Sources/RootView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/RootView.swift
@@ -148,6 +148,11 @@ struct RootView: View {
             selectedDetail = .linkList
             isSeeAllSelected = true
             selectedCategoryID = nil
+          },
+          onShowExistingLink: {
+            selectedDetail = .linkList
+            isSeeAllSelected = true
+            selectedCategoryID = nil
           }
         )
           .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/TapTap/Projects/TapTapMac/Sources/RootView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/RootView.swift
@@ -76,7 +76,7 @@ struct RootView: View {
           onSettings: { }
         )
         .transition(.move(edge: .leading).combined(with: .opacity))
-        .zIndex(1)
+        .zIndex(100)
       }
       
       ZStack(alignment: .top) {

--- a/TapTap/Projects/TapTapMac/Sources/RootView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/RootView.swift
@@ -28,6 +28,10 @@ struct RootView: View {
   @State private var selectedDetail: DetailDestination = .linkList
   @State private var isSaveSuccessToastPresented: Bool = false
   @State private var saveSuccessCategoryName: String = "전체"
+  @State private var isAddCategoryPopoverPresented: Bool = false
+  @State private var newCategoryName: String = ""
+  @State private var selectedNewCategoryIconNumber: Int = 1
+  @State private var isDuplicateCategoryName: Bool = false
   
   @ObservedObject var searchViewModel: SearchViewModel
   @State private var isSearchOverlayPresented: Bool = false
@@ -59,7 +63,7 @@ struct RootView: View {
             selectedCategoryID = nil
             searchViewModel.clearSearch()
           },
-          onAddCategory: { },
+          onAddCategory: showAddCategoryPopover,
           onSelectCategory: { category in
             selectedDetail = .linkList
             isSaveSuccessToastPresented = false
@@ -67,6 +71,8 @@ struct RootView: View {
             selectedCategoryID = category.id
             searchViewModel.clearSearch()
           },
+          onToggleCategoryFavorite: toggleCategoryFavorite,
+          onDeleteCategory: deleteCategory,
           onSettings: { }
         )
         .transition(.move(edge: .leading).combined(with: .opacity))
@@ -139,12 +145,34 @@ struct RootView: View {
         .padding(.leading, 16)
       }
     }
+    .overlay {
+      if isAddCategoryPopoverPresented {
+        Color.bgDim
+          .ignoresSafeArea()
+          .contentShape(Rectangle())
+          .onTapGesture {
+            closeAddCategoryPopover()
+          }
+        
+        AddCategoryPopover(
+          categoryName: $newCategoryName,
+          selectedIconNumber: $selectedNewCategoryIconNumber,
+          isDuplicateName: isDuplicateCategoryName,
+          onClose: closeAddCategoryPopover,
+          onSave: saveNewCategory
+        )
+        .zIndex(30)
+      }
+    }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .onAppear {
       searchViewModel.updateArticles(articles)
     }
     .onChange(of: articles) { _, newValue in
       searchViewModel.updateArticles(newValue)
+    }
+    .onChange(of: newCategoryName) { _, _ in
+      isDuplicateCategoryName = false
     }
   }
 
@@ -160,6 +188,75 @@ struct RootView: View {
   
   private var categoriesForList: [CategoryItem] {
     allCategories.filter { !$0.isFavorite }
+  }
+
+  private func showAddCategoryPopover() {
+    isSearchOverlayPresented = false
+    isSaveSuccessToastPresented = false
+    newCategoryName = ""
+    selectedNewCategoryIconNumber = 1
+    isDuplicateCategoryName = false
+    isAddCategoryPopoverPresented = true
+  }
+
+  private func closeAddCategoryPopover() {
+    isAddCategoryPopoverPresented = false
+    newCategoryName = ""
+    selectedNewCategoryIconNumber = 1
+    isDuplicateCategoryName = false
+  }
+
+  private func saveNewCategory() {
+    let trimmedName = newCategoryName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedName.isEmpty else { return }
+
+    let isDuplicate = allCategories.contains {
+      $0.categoryName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == trimmedName.lowercased()
+    } || trimmedName.lowercased() == "전체"
+
+    guard !isDuplicate else {
+      isDuplicateCategoryName = true
+      return
+    }
+
+    let newCategory = CategoryItem(
+      categoryName: trimmedName,
+      icon: CategoryIcon(number: selectedNewCategoryIconNumber)
+    )
+
+    modelContext.insert(newCategory)
+
+    do {
+      try modelContext.save()
+      isSeeAllSelected = false
+      selectedCategoryID = newCategory.id
+      closeAddCategoryPopover()
+    } catch {
+      modelContext.delete(newCategory)
+      isDuplicateCategoryName = true
+    }
+  }
+
+  private func toggleCategoryFavorite(_ categoryID: UUID) {
+    do {
+      try CategoryCommand(context: modelContext).toggleFavorite(id: categoryID)
+    } catch {
+      print("Failed to toggle category favorite: \(error)")
+    }
+  }
+
+  private func deleteCategory(_ categoryID: UUID) {
+    do {
+      if selectedCategoryID == categoryID {
+        selectedDetail = .linkList
+        isSeeAllSelected = true
+        selectedCategoryID = nil
+      }
+      
+      try CategoryCommand(context: modelContext).deleteCategory(id: categoryID)
+    } catch {
+      print("Failed to delete category: \(error)")
+    }
   }
   
   private var detailContent: some View {
@@ -188,7 +285,8 @@ struct RootView: View {
             selectedDetail = .linkList
             isSeeAllSelected = true
             selectedCategoryID = nil
-          }
+          },
+          onAddCategory: showAddCategoryPopover
         )
           .frame(maxWidth: .infinity, maxHeight: .infinity)
       }

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/AddCategoryPopover.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/AddCategoryPopover.swift
@@ -1,0 +1,300 @@
+//
+//  AddCategoryPopover.swift
+//  TapTapMac
+//
+
+import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
+
+import DesignSystem
+
+struct AddCategoryPopover: View {
+  @Binding var categoryName: String
+  @Binding var selectedIconNumber: Int
+  let isDuplicateName: Bool
+  let onClose: () -> Void
+  let onSave: () -> Void
+  
+  @FocusState private var isNameFocused: Bool
+  @State private var hoveredIconNumber: Int?
+  
+  private let maxNameCount = 14
+  private let columns = Array(
+    repeating: GridItem(.fixed(73.3), spacing: 16),
+    count: 6
+  )
+  
+  private var trimmedName: String {
+    categoryName.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+  
+  private var canSave: Bool {
+    !trimmedName.isEmpty && !isDuplicateName
+  }
+  
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      header
+      content
+      footer
+    }
+    .padding(.top, 10)
+    .padding(.bottom, 20)
+    .frame(width: 560)
+    .background(Color.background)
+    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    .shadow(color: Color.black.opacity(0.10), radius: 8, x: 0, y: 0)
+    .onAppear {
+      isNameFocused = true
+    }
+  }
+  
+  private var header: some View {
+    HStack(spacing: 12) {
+      Text("카테고리 추가하기")
+        .font(.B1_SB)
+        .foregroundStyle(Color.text1)
+        .frame(maxWidth: .infinity, alignment: .leading)
+      
+      Button(action: onClose) {
+        Image(icon: Icon.x)
+          .resizable()
+          .frame(width: 20, height: 20)
+          .foregroundStyle(Color.icon)
+          .frame(width: 40, height: 40)
+          .contentShape(Rectangle())
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("닫기")
+    }
+    .padding(.leading, 20)
+    .padding(.trailing, 10)
+  }
+  
+  private var content: some View {
+    VStack(alignment: .leading, spacing: 20) {
+      nameField
+      iconPicker
+    }
+    .padding(.vertical, 10)
+  }
+  
+  private var nameField: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("카테고리명")
+        .font(.B2_SB)
+        .foregroundStyle(Color.caption1)
+        .padding(.horizontal, 4)
+      
+      HStack(spacing: 8) {
+        TextField("카테고리명을 입력해주세요", text: $categoryName)
+          .textFieldStyle(.plain)
+          .font(.B1_M)
+          .foregroundStyle(Color.text1)
+          .focused($isNameFocused)
+          .onChange(of: categoryName) { _, newValue in
+            if newValue.count > maxNameCount {
+              categoryName = String(newValue.prefix(maxNameCount))
+            }
+          }
+        
+        HStack(spacing: 0) {
+          Text("\(categoryName.count)")
+            .foregroundStyle(Color.text1)
+          Text("/\(maxNameCount)")
+            .foregroundStyle(Color.caption2)
+        }
+        .font(.C2)
+      }
+      .padding(16)
+      .frame(height: 56)
+      .background(Color.n0)
+      .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+      .overlay {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .strokeBorder(isDuplicateName ? Color.danger : Color.divider1, lineWidth: 1)
+      }
+      
+      if isDuplicateName {
+        Text("이미 존재하는 카테고리예요")
+          .font(.C2)
+          .foregroundStyle(Color.danger)
+          .padding(.horizontal, 4)
+      }
+    }
+    .padding(.horizontal, 20)
+  }
+  
+  private var iconPicker: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("카테고리 아이콘")
+        .font(.B2_SB)
+        .foregroundStyle(Color.caption1)
+        .padding(.horizontal, 4)
+      
+      ZStack(alignment: .bottom) {
+        ScrollView {
+          LazyVGrid(columns: columns, alignment: .leading, spacing: 16) {
+            ForEach(1..<25, id: \.self) { iconNumber in
+              AddCategoryIconButton(
+                iconNumber: iconNumber,
+                isSelected: selectedIconNumber == iconNumber,
+                isHovered: hoveredIconNumber == iconNumber
+              ) {
+                selectedIconNumber = iconNumber
+              }
+              .onHover { isHovering in
+                hoveredIconNumber = isHovering ? iconNumber : nil
+              }
+            }
+          }
+          .padding(.bottom, 10)
+        }
+        .scrollIndicators(.hidden)
+        .background(HiddenScrollIndicatorsConfigurator())
+        
+        LinearGradient(
+          colors: [
+            Color.bgButtonGrad4.opacity(0),
+            Color.background.opacity(0.90),
+            Color.background
+          ],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+        .frame(height: 32)
+        .allowsHitTesting(false)
+      }
+      .frame(height: 243)
+    }
+    .padding(.horizontal, 20)
+  }
+  
+  private var footer: some View {
+    HStack {
+      Spacer()
+      
+      Button(action: onSave) {
+        Text("확인")
+          .font(.H4_SB)
+          .foregroundStyle(canSave ? Color.textw : Color.caption2)
+          .padding(.horizontal, 22)
+          .frame(height: 48)
+          .background(canSave ? Color.bl6 : Color.n40)
+          .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+      }
+      .buttonStyle(.plain)
+      .disabled(!canSave)
+    }
+    .padding(.horizontal, 20)
+  }
+}
+
+#if os(macOS)
+private struct HiddenScrollIndicatorsConfigurator: NSViewRepresentable {
+  func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    DispatchQueue.main.async {
+      hideScrollIndicators(from: view)
+    }
+    return view
+  }
+  
+  func updateNSView(_ nsView: NSView, context: Context) {
+    DispatchQueue.main.async {
+      hideScrollIndicators(from: nsView)
+    }
+  }
+  
+  private func hideScrollIndicators(from view: NSView) {
+    guard let scrollView = scrollView(near: view) else { return }
+    scrollView.autohidesScrollers = true
+    scrollView.scrollerStyle = .overlay
+    scrollView.verticalScroller?.isHidden = true
+    scrollView.horizontalScroller?.isHidden = true
+    scrollView.verticalScroller?.alphaValue = 0
+    scrollView.horizontalScroller?.alphaValue = 0
+  }
+  
+  private func scrollView(near view: NSView) -> NSScrollView? {
+    if let enclosingScrollView = view.enclosingScrollView {
+      return enclosingScrollView
+    }
+    
+    var parent = view.superview
+    while let current = parent {
+      if let scrollView = current as? NSScrollView {
+        return scrollView
+      }
+      if let scrollView = firstScrollView(in: current.subviews) {
+        return scrollView
+      }
+      parent = current.superview
+    }
+    
+    return firstScrollView(in: view.window?.contentView?.subviews ?? [])
+  }
+  
+  private func firstScrollView(in views: [NSView]) -> NSScrollView? {
+    for view in views {
+      if let scrollView = view as? NSScrollView {
+        return scrollView
+      }
+      if let scrollView = firstScrollView(in: view.subviews) {
+        return scrollView
+      }
+    }
+    
+    return nil
+  }
+}
+#else
+private struct HiddenScrollIndicatorsConfigurator: View {
+  var body: some View {
+    EmptyView()
+  }
+}
+#endif
+
+private struct AddCategoryIconButton: View {
+  let iconNumber: Int
+  let isSelected: Bool
+  let isHovered: Bool
+  let onTap: () -> Void
+  
+  var body: some View {
+    Button(action: onTap) {
+      RoundedRectangle(cornerRadius: 10.619, style: .continuous)
+        .fill(backgroundColor)
+        .frame(width: 73.3, height: 73.3)
+        .overlay {
+          DesignSystemAsset.primaryCategoryIcon(number: iconNumber)
+            .resizable()
+            .frame(width: 44.245, height: 44.245)
+            .opacity(0.8)
+        }
+        .overlay {
+          RoundedRectangle(cornerRadius: 9.619, style: .continuous)
+            .stroke(isSelected ? Color.bl6 : Color.clear, lineWidth: 1.25)
+            .padding(1)
+        }
+    }
+    .buttonStyle(.plain)
+    .shadow(color: Color.bgShadow3, radius: 3.54, x: 0, y: 0)
+    .accessibilityLabel("카테고리 아이콘 \(iconNumber)")
+  }
+  
+  private var backgroundColor: Color {
+    if isSelected {
+      return Color.bl1
+    }
+    
+    if isHovered {
+      return Color.statePressedDim
+    }
+    
+    return Color.n0
+  }
+}

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarAssets.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarAssets.swift
@@ -7,14 +7,10 @@ import SwiftUI
 
 import DesignSystem
 
-enum MacSidebarFigmaAsset {
-  static let streetlights = URL(string: "https://www.figma.com/api/mcp/asset/e2f49374-962a-4a89-839b-9a65dc9b4e2d")!
-  static let logo = URL(string: "https://www.figma.com/api/mcp/asset/2854f629-ba6c-40dd-99bb-5550f318070c")!
-  static let sidebarToggle = URL(string: "https://www.figma.com/api/mcp/asset/03d8d5ba-29b7-490f-b6fc-e547c77bf340")!
-  static let plusVector2 = URL(string: "https://www.figma.com/api/mcp/asset/4ac77856-c2e7-4ab8-8973-5be37d17d083")!
-  static let plusVector3 = URL(string: "https://www.figma.com/api/mcp/asset/90080e26-b051-479c-8fb8-3e38d51957ac")!
-  static let link = URL(string: "https://www.figma.com/api/mcp/asset/fac4149c-463d-47c4-9aba-2224c1017535")!
-  static let settings = URL(string: "https://www.figma.com/api/mcp/asset/4d0544d6-a774-464a-952c-d79643021759")!
+enum MacSidebarAsset {
+  static let wordmark = DesignSystemAsset.logo
+  static let logoLeft = DesignSystemAsset.logoLeft
+  static let logoRight = DesignSystemAsset.logoRight
 }
 
 enum SidebarForeground {
@@ -24,34 +20,26 @@ enum SidebarForeground {
   static let iconGray = Color.iconGray
 }
 
-struct MacRemoteImage: View {
-  let url: URL?
+struct MacSidebarAssetImage: View {
+  let asset: DesignSystemImages
   var contentMode: ContentMode = .fit
-  var showsPlaceholder: Bool = false
 
   var body: some View {
-    AsyncImage(url: url) { phase in
-      switch phase {
-      case .success(let image):
-        image
-          .resizable()
-          .aspectRatio(contentMode: contentMode)
-      case .failure:
-        if showsPlaceholder {
-          Color.n20
-        } else {
-          Color.clear
-        }
-      case .empty:
-        if showsPlaceholder {
-          Color.n20.opacity(0.6)
-        } else {
-          Color.clear
-        }
-      @unknown default:
-        Color.clear
-      }
+    asset.swiftUIImage
+      .resizable()
+      .aspectRatio(contentMode: contentMode)
+  }
+}
+
+struct MacSidebarLogoIcon: View {
+  var body: some View {
+    HStack(spacing: -2) {
+      MacSidebarAssetImage(asset: MacSidebarAsset.logoLeft)
+        .frame(width: 20, height: 20)
+      MacSidebarAssetImage(asset: MacSidebarAsset.logoRight)
+        .frame(width: 20, height: 20)
     }
+    .frame(width: 36, height: 36)
   }
 }
 
@@ -59,15 +47,10 @@ struct SidebarToggleIcon: View {
   var isCollapsed: Bool
 
   var body: some View {
-    ZStack {
-      Image(systemName: "sidebar.leading")
-        .font(.system(size: 14, weight: .medium))
-        .foregroundStyle(SidebarForeground.iconGray)
-
-      MacRemoteImage(url: MacSidebarFigmaAsset.sidebarToggle, showsPlaceholder: false)
-        .scaleEffect(x: isCollapsed ? -1 : 1, y: 1)
-        .frame(width: 24, height: 24)
-    }
+    Image(icon: isCollapsed ? Icon.sidebarOpen : Icon.sidebarClose)
+      .resizable()
+      .scaledToFit()
+      .frame(width: 24, height: 24)
     .frame(width: 32, height: 32)
     .background(
       RoundedRectangle(cornerRadius: 8, style: .continuous)
@@ -82,15 +65,10 @@ struct SidebarToggleIcon: View {
 
 struct SidebarPlusIcon: View {
   var body: some View {
-    ZStack {
-      MacRemoteImage(url: MacSidebarFigmaAsset.plusVector2)
-        .frame(width: 10, height: 10)
-        .rotationEffect(.degrees(45))
-      MacRemoteImage(url: MacSidebarFigmaAsset.plusVector3)
-        .frame(width: 10, height: 10)
-        .rotationEffect(.degrees(45))
-    }
-    .frame(width: 12, height: 12)
+    Image(icon: Icon.plusThin)
+      .resizable()
+      .scaledToFit()
+      .frame(width: 24, height: 24)
   }
 }
 
@@ -101,14 +79,12 @@ struct SeeMoreButton: View {
         .fill(Color.n30)
         .frame(width: 24, height: 24)
 
-      HStack(spacing: 3.5) {
-        Circle().fill(SidebarForeground.caption2).frame(width: 2, height: 2)
-        Circle().fill(SidebarForeground.caption2).frame(width: 2, height: 2)
-        Circle().fill(SidebarForeground.caption2).frame(width: 2, height: 2)
-      }
+      Image(icon: Icon.moreVertical)
+        .resizable()
+        .scaledToFit()
+        .frame(width: 16, height: 16)
     }
     .frame(width: 24, height: 24)
     .accessibilityLabel("더보기")
   }
 }
-

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarView.swift
@@ -129,4 +129,3 @@ public struct MacSidebarView: View {
     .shadow(color: .bgShadow1, radius: 3, x: 0, y: 2)
   }
 }
-

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarView.swift
@@ -21,6 +21,8 @@ public struct MacSidebarView: View {
   public var onSeeAllLinks: () -> Void
   public var onAddCategory: () -> Void
   public var onSelectCategory: (CategoryItem) -> Void
+  public var onToggleCategoryFavorite: (UUID) -> Void
+  public var onDeleteCategory: (UUID) -> Void
   public var onSettings: () -> Void
   
   @State private var hoveredCategoryID: UUID?
@@ -37,6 +39,8 @@ public struct MacSidebarView: View {
     onSeeAllLinks: @escaping () -> Void,
     onAddCategory: @escaping () -> Void,
     onSelectCategory: @escaping (CategoryItem) -> Void,
+    onToggleCategoryFavorite: @escaping (UUID) -> Void,
+    onDeleteCategory: @escaping (UUID) -> Void,
     onSettings: @escaping () -> Void
   ) {
     self.totalLinkCount = totalLinkCount
@@ -50,6 +54,8 @@ public struct MacSidebarView: View {
     self.onSeeAllLinks = onSeeAllLinks
     self.onAddCategory = onAddCategory
     self.onSelectCategory = onSelectCategory
+    self.onToggleCategoryFavorite = onToggleCategoryFavorite
+    self.onDeleteCategory = onDeleteCategory
     self.onSettings = onSettings
   }
 
@@ -75,7 +81,9 @@ public struct MacSidebarView: View {
             selectedCategoryID: selectedCategoryID,
             isSeeAllSelected: isSeeAllSelected,
             hoveredCategoryID: $hoveredCategoryID,
-            onSelectCategory: onSelectCategory
+            onSelectCategory: onSelectCategory,
+            onToggleCategoryFavorite: onToggleCategoryFavorite,
+            onDeleteCategory: onDeleteCategory
           )
           SidebarCategoryListView(
             categories: categories,
@@ -83,7 +91,9 @@ public struct MacSidebarView: View {
             isSeeAllSelected: isSeeAllSelected,
             hoveredCategoryID: $hoveredCategoryID,
             onAddCategory: onAddCategory,
-            onSelectCategory: onSelectCategory
+            onSelectCategory: onSelectCategory,
+            onToggleCategoryFavorite: onToggleCategoryFavorite,
+            onDeleteCategory: onDeleteCategory
           )
         }
       }

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarView.swift
@@ -26,6 +26,7 @@ public struct MacSidebarView: View {
   public var onSettings: () -> Void
   
   @State private var hoveredCategoryID: UUID?
+  @State private var presentedMenuCategoryID: UUID?
 
   public init(
     totalLinkCount: Int,
@@ -61,8 +62,19 @@ public struct MacSidebarView: View {
 
   public var body: some View {
     let width: CGFloat = isCollapsed ? 56 : 290
+    let sidebarShape = UnevenRoundedRectangle(
+      topLeadingRadius: 0,
+      bottomLeadingRadius: 0,
+      bottomTrailingRadius: 16,
+      topTrailingRadius: 16,
+      style: .continuous
+    )
+
     ZStack(alignment: .bottomLeading) {
-      Color.n0
+      sidebarShape
+        .fill(Color.n0)
+        .shadow(color: .bgShadow2, radius: 2, x: 0, y: 2)
+        .shadow(color: .bgShadow1, radius: 3, x: 0, y: 2)
 
       VStack(alignment: .leading, spacing: 16) {
         SidebarHeaderView(
@@ -81,6 +93,7 @@ public struct MacSidebarView: View {
             selectedCategoryID: selectedCategoryID,
             isSeeAllSelected: isSeeAllSelected,
             hoveredCategoryID: $hoveredCategoryID,
+            presentedMenuCategoryID: $presentedMenuCategoryID,
             onSelectCategory: onSelectCategory,
             onToggleCategoryFavorite: onToggleCategoryFavorite,
             onDeleteCategory: onDeleteCategory
@@ -90,6 +103,7 @@ public struct MacSidebarView: View {
             selectedCategoryID: selectedCategoryID,
             isSeeAllSelected: isSeeAllSelected,
             hoveredCategoryID: $hoveredCategoryID,
+            presentedMenuCategoryID: $presentedMenuCategoryID,
             onAddCategory: onAddCategory,
             onSelectCategory: onSelectCategory,
             onToggleCategoryFavorite: onToggleCategoryFavorite,
@@ -100,6 +114,7 @@ public struct MacSidebarView: View {
       .padding(.top, isCollapsed ? 8 : 16)
       .padding(.horizontal, isCollapsed ? 8 : 16)
       .padding(.bottom, 20)
+      .zIndex(2)
 
       VStack {
         Spacer()
@@ -111,27 +126,60 @@ public struct MacSidebarView: View {
         .frame(height: 72)
         .allowsHitTesting(false)
       }
+      .zIndex(1)
 
       if !isCollapsed {
         SidebarSettingsButton(onSettings: onSettings)
           .padding(.leading, 20)
           .padding(.bottom, 20)
+          .zIndex(1)
       }
     }
     .frame(width: width, alignment: .leading)
     .frame(maxHeight: .infinity, alignment: .topLeading)
     .ignoresSafeArea(edges: .vertical)
     .contentShape(Rectangle())
-    .clipShape(
-      UnevenRoundedRectangle(
-        topLeadingRadius: 0,
-        bottomLeadingRadius: 0,
-        bottomTrailingRadius: 16,
-        topTrailingRadius: 16,
-        style: .continuous
-      )
-    )
-    .shadow(color: .bgShadow2, radius: 2, x: 0, y: 2)
-    .shadow(color: .bgShadow1, radius: 3, x: 0, y: 2)
+    .overlayPreferenceValue(SidebarCategoryMenuAnchorPreferenceKey.self) { anchors in
+      GeometryReader { proxy in
+        if presentedMenuCategoryID != nil {
+          Color.clear
+            .contentShape(Rectangle())
+            .frame(width: 10_000, height: 10_000)
+            .offset(x: -2_000, y: -2_000)
+            .onTapGesture {
+              presentedMenuCategoryID = nil
+            }
+            .zIndex(999)
+        }
+
+        if
+          let categoryID = presentedMenuCategoryID,
+          let anchor = anchors[categoryID],
+          let category = category(id: categoryID)
+        {
+          let rect = proxy[anchor]
+
+          SidebarCategoryMorePopup(
+            favoriteTitle: category.isFavorite ? "즐겨찾기에서 제거하기" : "즐겨찾기에 추가하기",
+            onToggleFavorite: {
+              presentedMenuCategoryID = nil
+              onToggleCategoryFavorite(categoryID)
+            },
+            onOpenInNewTab: { presentedMenuCategoryID = nil },
+            onEdit: { presentedMenuCategoryID = nil },
+            onDelete: {
+              presentedMenuCategoryID = nil
+              onDeleteCategory(categoryID)
+            }
+          )
+          .offset(x: rect.minX, y: rect.minY)
+          .zIndex(1000)
+        }
+      }
+    }
+  }
+
+  private func category(id: UUID) -> CategoryItem? {
+    favoriteCategories.first { $0.id == id } ?? categories.first { $0.id == id }
   }
 }

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarView.swift
@@ -102,11 +102,7 @@ public struct MacSidebarView: View {
         .allowsHitTesting(false)
       }
 
-      if isCollapsed {
-        SidebarSettingsButton(onSettings: onSettings)
-          .padding(.leading, 8)
-          .padding(.bottom, 20)
-      } else {
+      if !isCollapsed {
         SidebarSettingsButton(onSettings: onSettings)
           .padding(.leading, 20)
           .padding(.bottom, 20)

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarBookmarksView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarBookmarksView.swift
@@ -38,8 +38,9 @@ struct SidebarBookmarksView: View {
           )
         }
       }
+      .frame(maxWidth: .infinity, alignment: .leading)
       .padding(.vertical, 6)
     }
+    .frame(maxWidth: .infinity, alignment: .leading)
   }
 }
-

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarBookmarksView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarBookmarksView.swift
@@ -14,6 +14,8 @@ struct SidebarBookmarksView: View {
   let isSeeAllSelected: Bool
   @Binding var hoveredCategoryID: UUID?
   let onSelectCategory: (CategoryItem) -> Void
+  let onToggleCategoryFavorite: (UUID) -> Void
+  let onDeleteCategory: (UUID) -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
@@ -30,11 +32,16 @@ struct SidebarBookmarksView: View {
       VStack(alignment: .leading, spacing: 8) {
         ForEach(categories, id: \.id) { category in
           SidebarCategoryRow(
-            category: category,
+            categoryID: category.id,
+            categoryName: category.categoryName,
+            iconNumber: category.icon.number,
+            isFavorite: category.isFavorite,
             countText: "\((category.links ?? []).count)개",
             isSelected: selectedCategoryID == category.id && !isSeeAllSelected,
             hoveredCategoryID: $hoveredCategoryID,
-            onSelectCategory: onSelectCategory
+            onSelectCategory: { _ in onSelectCategory(category) },
+            onToggleFavorite: onToggleCategoryFavorite,
+            onDeleteCategory: onDeleteCategory
           )
         }
       }

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarBookmarksView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarBookmarksView.swift
@@ -13,6 +13,7 @@ struct SidebarBookmarksView: View {
   let selectedCategoryID: UUID?
   let isSeeAllSelected: Bool
   @Binding var hoveredCategoryID: UUID?
+  @Binding var presentedMenuCategoryID: UUID?
   let onSelectCategory: (CategoryItem) -> Void
   let onToggleCategoryFavorite: (UUID) -> Void
   let onDeleteCategory: (UUID) -> Void
@@ -39,6 +40,7 @@ struct SidebarBookmarksView: View {
             countText: "\((category.links ?? []).count)개",
             isSelected: selectedCategoryID == category.id && !isSeeAllSelected,
             hoveredCategoryID: $hoveredCategoryID,
+            presentedMenuCategoryID: $presentedMenuCategoryID,
             onSelectCategory: { _ in onSelectCategory(category) },
             onToggleFavorite: onToggleCategoryFavorite,
             onDeleteCategory: onDeleteCategory

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryListView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryListView.swift
@@ -36,14 +36,15 @@ struct SidebarCategoryListView: View {
               )
             }
           }
+          .frame(maxWidth: .infinity, alignment: .leading)
           .padding(.bottom, 56)
         }
         .scrollIndicators(.hidden)
 
         SidebarCategorySectionHeader(onAddCategory: onAddCategory)
       }
-      .frame(maxHeight: .infinity)
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
+    .frame(maxWidth: .infinity, alignment: .leading)
   }
 }
-

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryListView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryListView.swift
@@ -15,6 +15,8 @@ struct SidebarCategoryListView: View {
   @Binding var hoveredCategoryID: UUID?
   let onAddCategory: () -> Void
   let onSelectCategory: (CategoryItem) -> Void
+  let onToggleCategoryFavorite: (UUID) -> Void
+  let onDeleteCategory: (UUID) -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
@@ -28,11 +30,16 @@ struct SidebarCategoryListView: View {
             Color.clear.frame(height: 38)
             ForEach(categories, id: \.id) { category in
               SidebarCategoryRow(
-                category: category,
+                categoryID: category.id,
+                categoryName: category.categoryName,
+                iconNumber: category.icon.number,
+                isFavorite: category.isFavorite,
                 countText: "\((category.links ?? []).count)개",
                 isSelected: selectedCategoryID == category.id && !isSeeAllSelected,
                 hoveredCategoryID: $hoveredCategoryID,
-                onSelectCategory: onSelectCategory
+                onSelectCategory: { _ in onSelectCategory(category) },
+                onToggleFavorite: onToggleCategoryFavorite,
+                onDeleteCategory: onDeleteCategory
               )
             }
           }

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryListView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryListView.swift
@@ -13,6 +13,7 @@ struct SidebarCategoryListView: View {
   let selectedCategoryID: UUID?
   let isSeeAllSelected: Bool
   @Binding var hoveredCategoryID: UUID?
+  @Binding var presentedMenuCategoryID: UUID?
   let onAddCategory: () -> Void
   let onSelectCategory: (CategoryItem) -> Void
   let onToggleCategoryFavorite: (UUID) -> Void
@@ -37,6 +38,7 @@ struct SidebarCategoryListView: View {
                 countText: "\((category.links ?? []).count)개",
                 isSelected: selectedCategoryID == category.id && !isSeeAllSelected,
                 hoveredCategoryID: $hoveredCategoryID,
+                presentedMenuCategoryID: $presentedMenuCategoryID,
                 onSelectCategory: { _ in onSelectCategory(category) },
                 onToggleFavorite: onToggleCategoryFavorite,
                 onDeleteCategory: onDeleteCategory

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryRow.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryRow.swift
@@ -45,13 +45,15 @@ struct SidebarCategoryRow: View {
       }
       .padding(.leading, 12)
       .padding(.trailing, 6)
-      .frame(height: 36)
+      .frame(maxWidth: .infinity, minHeight: 36, maxHeight: 36, alignment: .leading)
+      .contentShape(Rectangle())
       .background(
         RoundedRectangle(cornerRadius: 8, style: .continuous)
           .fill(isSelected ? Color.bl1 : (isHovered ? Color.n20 : Color.clear))
       )
     }
     .buttonStyle(.plain)
+    .frame(maxWidth: .infinity, alignment: .leading)
     .onHover { isHovering in
       if isHovering {
         hoveredCategoryID = category.id
@@ -61,4 +63,3 @@ struct SidebarCategoryRow: View {
     }
   }
 }
-

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryRow.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryRow.swift
@@ -9,57 +9,169 @@ import Core
 import DesignSystem
 
 struct SidebarCategoryRow: View {
-  let category: CategoryItem
+  let categoryID: UUID
+  let categoryName: String
+  let iconNumber: Int
+  let isFavorite: Bool
   let countText: String
   let isSelected: Bool
   @Binding var hoveredCategoryID: UUID?
-  let onSelectCategory: (CategoryItem) -> Void
+  let onSelectCategory: (UUID) -> Void
+  let onToggleFavorite: (UUID) -> Void
+  let onDeleteCategory: (UUID) -> Void
 
-  private var isHovered: Bool { hoveredCategoryID == category.id }
+  @State private var isMenuPresented: Bool = false
+
+  private var isHovered: Bool { hoveredCategoryID == categoryID }
 
   var body: some View {
-    Button {
-      onSelectCategory(category)
-    } label: {
-      HStack(spacing: 10) {
-        DesignSystemAsset.categoryIcon(number: category.icon.number)
-          .resizable()
-          .frame(width: 24, height: 24)
+    HStack(spacing: 10) {
+      DesignSystemAsset.categoryIcon(number: iconNumber)
+        .resizable()
+        .frame(width: 24, height: 24)
 
-        Text(category.categoryName)
-          .font(.B1_SB)
-          .foregroundStyle(SidebarForeground.text1)
-          .lineLimit(1)
-          .truncationMode(.tail)
-          .frame(maxWidth: .infinity, alignment: .leading)
+      Text(categoryName)
+        .font(.B1_SB)
+        .foregroundStyle(SidebarForeground.text1)
+        .lineLimit(1)
+        .truncationMode(.tail)
+        .frame(maxWidth: .infinity, alignment: .leading)
 
-        if isHovered && !isSelected {
+      if isHovered || isMenuPresented {
+        Button {
+          isMenuPresented.toggle()
+        } label: {
           SeeMoreButton()
-            .padding(.trailing, 6)
-        } else {
-          Text(countText)
-            .font(.B2_M)
-            .foregroundStyle(SidebarForeground.caption2)
-            .padding(.trailing, 6)
         }
+        .buttonStyle(.plain)
+        .popover(isPresented: $isMenuPresented, arrowEdge: .trailing) {
+          SidebarCategoryMorePopup(
+            favoriteTitle: isFavorite ? "즐겨찾기에서 제거하기" : "즐겨찾기에 추가하기",
+            onToggleFavorite: {
+              isMenuPresented = false
+              onToggleFavorite(categoryID)
+            },
+            onOpenInNewTab: { isMenuPresented = false },
+            onEdit: { isMenuPresented = false },
+            onDelete: {
+              isMenuPresented = false
+              onDeleteCategory(categoryID)
+            }
+          )
+        }
+        .padding(.trailing, 6)
+      } else {
+        Text(countText)
+          .font(.B2_M)
+          .foregroundStyle(SidebarForeground.caption2)
+          .padding(.trailing, 6)
       }
-      .padding(.leading, 12)
-      .padding(.trailing, 6)
-      .frame(maxWidth: .infinity, minHeight: 36, maxHeight: 36, alignment: .leading)
-      .contentShape(Rectangle())
-      .background(
-        RoundedRectangle(cornerRadius: 8, style: .continuous)
-          .fill(isSelected ? Color.bl1 : (isHovered ? Color.n20 : Color.clear))
-      )
     }
-    .buttonStyle(.plain)
+    .padding(.leading, 12)
+    .padding(.trailing, 6)
+    .frame(maxWidth: .infinity, minHeight: 36, maxHeight: 36, alignment: .leading)
+    .contentShape(Rectangle())
+    .background(
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .fill(isSelected ? Color.bl1 : (isHovered ? Color.n20 : Color.clear))
+    )
     .frame(maxWidth: .infinity, alignment: .leading)
+    .onTapGesture {
+      onSelectCategory(categoryID)
+    }
     .onHover { isHovering in
       if isHovering {
-        hoveredCategoryID = category.id
-      } else if hoveredCategoryID == category.id {
+        hoveredCategoryID = categoryID
+      } else if hoveredCategoryID == categoryID {
         hoveredCategoryID = nil
       }
     }
+  }
+}
+
+private struct SidebarCategoryMorePopup: View {
+  let favoriteTitle: String
+  let onToggleFavorite: () -> Void
+  let onOpenInNewTab: () -> Void
+  let onEdit: () -> Void
+  let onDelete: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      SidebarCategoryMorePopupButton(
+        title: favoriteTitle,
+        icon: Icon.bookmark,
+        action: onToggleFavorite
+      )
+
+      Rectangle()
+        .fill(Color.divider1)
+        .frame(height: 0.5)
+
+      SidebarCategoryMorePopupButton(
+        title: "새 탭에서 열기",
+        icon: Icon.openWindow,
+        action: onOpenInNewTab
+      )
+
+      SidebarCategoryMorePopupButton(
+        title: "카테고리 편집하기",
+        icon: Icon.macEdit,
+        action: onEdit
+      )
+
+      SidebarCategoryMorePopupButton(
+        title: "카테고리 삭제하기",
+        icon: Icon.trash,
+        foregroundColor: Color.danger,
+        backgroundColor: Color.bgDimDanger,
+        action: onDelete
+      )
+    }
+    .padding(4)
+    .frame(width: 168, alignment: .leading)
+    .background(Color.n0)
+    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .strokeBorder(Color.divider2, lineWidth: 0.5)
+    }
+    .shadow(color: Color.bgShadow2, radius: 4, x: 0, y: 2)
+    .shadow(color: Color.bgShadow1, radius: 6, x: 0, y: 2)
+  }
+}
+
+private struct SidebarCategoryMorePopupButton: View {
+  let title: String
+  let icon: String
+  var foregroundColor: Color = Color.text1
+  var backgroundColor: Color = Color.clear
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: 8) {
+        Image(icon: icon)
+          .resizable()
+          .renderingMode(.template)
+          .scaledToFit()
+          .frame(width: 16, height: 16)
+          .foregroundStyle(foregroundColor)
+
+        Text(title)
+          .font(.B2_M)
+          .foregroundStyle(foregroundColor)
+          .lineLimit(1)
+          .frame(width: 95, alignment: .leading)
+      }
+      .padding(.leading, 8)
+      .padding(.trailing, 40)
+      .padding(.vertical, 6)
+      .frame(width: 160, alignment: .leading)
+      .background(backgroundColor)
+      .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+      .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+    }
+    .buttonStyle(.plain)
   }
 }

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryRow.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategoryRow.swift
@@ -16,13 +16,14 @@ struct SidebarCategoryRow: View {
   let countText: String
   let isSelected: Bool
   @Binding var hoveredCategoryID: UUID?
+  @Binding var presentedMenuCategoryID: UUID?
   let onSelectCategory: (UUID) -> Void
   let onToggleFavorite: (UUID) -> Void
   let onDeleteCategory: (UUID) -> Void
 
-  @State private var isMenuPresented: Bool = false
-
   private var isHovered: Bool { hoveredCategoryID == categoryID }
+  private var isMenuPresented: Bool { presentedMenuCategoryID == categoryID }
+  private let trailingAccessoryWidth: CGFloat = 32
 
   var body: some View {
     HStack(spacing: 10) {
@@ -39,32 +40,23 @@ struct SidebarCategoryRow: View {
 
       if isHovered || isMenuPresented {
         Button {
-          isMenuPresented.toggle()
+          presentedMenuCategoryID = isMenuPresented ? nil : categoryID
         } label: {
           SeeMoreButton()
         }
         .buttonStyle(.plain)
-        .popover(isPresented: $isMenuPresented, arrowEdge: .trailing) {
-          SidebarCategoryMorePopup(
-            favoriteTitle: isFavorite ? "즐겨찾기에서 제거하기" : "즐겨찾기에 추가하기",
-            onToggleFavorite: {
-              isMenuPresented = false
-              onToggleFavorite(categoryID)
-            },
-            onOpenInNewTab: { isMenuPresented = false },
-            onEdit: { isMenuPresented = false },
-            onDelete: {
-              isMenuPresented = false
-              onDeleteCategory(categoryID)
-            }
-          )
+        .anchorPreference(
+          key: SidebarCategoryMenuAnchorPreferenceKey.self,
+          value: .bounds
+        ) { anchor in
+          isMenuPresented ? [categoryID: anchor] : [:]
         }
-        .padding(.trailing, 6)
+        .frame(width: trailingAccessoryWidth, alignment: .trailing)
       } else {
         Text(countText)
           .font(.B2_M)
           .foregroundStyle(SidebarForeground.caption2)
-          .padding(.trailing, 6)
+          .frame(width: trailingAccessoryWidth, alignment: .trailing)
       }
     }
     .padding(.leading, 12)
@@ -86,10 +78,22 @@ struct SidebarCategoryRow: View {
         hoveredCategoryID = nil
       }
     }
+    .zIndex(isMenuPresented ? 1 : 0)
   }
 }
 
-private struct SidebarCategoryMorePopup: View {
+struct SidebarCategoryMenuAnchorPreferenceKey: PreferenceKey {
+  static var defaultValue: [UUID: Anchor<CGRect>] = [:]
+
+  static func reduce(
+    value: inout [UUID: Anchor<CGRect>],
+    nextValue: () -> [UUID: Anchor<CGRect>]
+  ) {
+    value.merge(nextValue(), uniquingKeysWith: { _, newValue in newValue })
+  }
+}
+
+struct SidebarCategoryMorePopup: View {
   let favoriteTitle: String
   let onToggleFavorite: () -> Void
   let onOpenInNewTab: () -> Void

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategorySectionHeader.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategorySectionHeader.swift
@@ -47,4 +47,3 @@ struct SidebarCategorySectionHeader: View {
     .frame(height: 40)
   }
 }
-

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarHeaderView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarHeaderView.swift
@@ -39,5 +39,6 @@ struct SidebarHeaderView: View {
       }
       .padding(.bottom, isCollapsed ? 0 : 8)
     }
+    .frame(maxWidth: .infinity, alignment: .topLeading)
   }
 }

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarHeaderView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarHeaderView.swift
@@ -14,15 +14,14 @@ struct SidebarHeaderView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 30) {
       if !isCollapsed {
-        MacRemoteImage(url: MacSidebarFigmaAsset.streetlights)
+        MacSidebarAssetImage(asset: MacSidebarAsset.wordmark)
           .frame(width: 52, height: 12)
       }
 
       HStack(spacing: 12) {
         if !isCollapsed {
           HStack(spacing: 12) {
-            MacRemoteImage(url: MacSidebarFigmaAsset.logo, contentMode: .fill)
-              .frame(width: 36, height: 36)
+            MacSidebarLogoIcon()
               .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
 
             Text("탭탭")
@@ -42,4 +41,3 @@ struct SidebarHeaderView: View {
     }
   }
 }
-

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarMyLinksView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarMyLinksView.swift
@@ -39,7 +39,9 @@ struct SidebarMyLinksView: View {
 
       Button(action: onSeeAllLinks) {
         HStack(spacing: 10) {
-          MacRemoteImage(url: MacSidebarFigmaAsset.link)
+          Image(icon: Icon.linkMac)
+            .resizable()
+            .scaledToFit()
             .frame(width: 24, height: 24)
           Text("모두 보기")
             .font(.B1_SB)
@@ -63,4 +65,3 @@ struct SidebarMyLinksView: View {
     }
   }
 }
-

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarSettingsButton.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarSettingsButton.swift
@@ -12,7 +12,9 @@ struct SidebarSettingsButton: View {
 
   var body: some View {
     Button(action: onSettings) {
-      MacRemoteImage(url: MacSidebarFigmaAsset.settings)
+      Image(icon: Icon.settings)
+        .resizable()
+        .scaledToFit()
         .frame(width: 24, height: 24)
         .frame(width: 32, height: 32)
     }
@@ -28,4 +30,3 @@ struct SidebarSettingsButton: View {
     .shadow(color: .bgShadow3, radius: 8, x: 0, y: 0)
   }
 }
-

--- a/TapTap/Tuist/Package.resolved
+++ b/TapTap/Tuist/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "2d60d4082dfb4978974307acf0f00dfa20e5f621",
-        "version" : "1.22.3"
+        "revision" : "1eaa6fa2ee57ac42843283b9fd3457af408c858d",
+        "version" : "1.25.5"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "91415670c91d41e8e1872ef6fe1bf118e20dee37",
-        "version" : "2.5.1"
+        "revision" : "32f35241b8be0719c4c7f00eb27713b1cadb6248",
+        "version" : "2.8.0"
       }
     },
     {


### PR DESCRIPTION
## 작업 내용
- 사이드바 접힘/열림 상태 동작을 수정했습니다.
- 사이드바 카테고리 메뉴 표시 위치와 외부 클릭 dismiss 동작을 개선했습니다.
- 디자인 시스템 아이콘/에셋 사용 기준에 맞춰 사이드바 UI를 조정했습니다.

## 검증
- tuist generate
- xcodebuild -workspace TapTap.xcworkspace -scheme TapTapMac -destination platform=macOS build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새 기능**
  * 링크의 제목과 이미지를 자동으로 추출하여 표시하는 메타데이터 추출 기능 추가
  * Mac 앱에서 링크 추가 화면 구현
  * 카테고리 즐겨찾기 토글 및 삭제 기능 추가
  * 카테고리 추가 팝오버 UI 추가

* **개선 사항**
  * 원격 이미지 자산을 로컬 디자인 시스템 자산으로 통합하여 로딩 성능 개선
  * 링크 중복 확인 로직 개선

* **의존성**
  * swift-composable-architecture 1.22.3 → 1.25.5 업데이트
  * swift-navigation 2.5.1 → 2.8.0 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->