### PR TITLE
Feature: #108 링크 리스트 새 탭 기능 추가하기

### DIFF
--- a/TapTap/Projects/MacFeature/LinkListFeature/Sources/Components/LinkTabBar.swift
+++ b/TapTap/Projects/MacFeature/LinkListFeature/Sources/Components/LinkTabBar.swift
@@ -14,21 +14,37 @@ struct LinkTabBar: View {
   let selectedTabID: String?
   let onSelect: (String) -> Void
   let onClose: (String) -> Void
+  let onNewTab: () -> Void
 
   var body: some View {
-    HStack(spacing: 0) {
-      ForEach(tabs) { tab in
-        tabItem(tab)
+    GeometryReader { geometry in
+      let plusButtonWidth: CGFloat = 36
+      let layout = calculatedLayout(
+        totalWidth: geometry.size.width,
+        plusButtonWidth: plusButtonWidth
+      )
+
+      HStack(spacing: 0) {
+        HStack(spacing: 0) {
+          ForEach(tabs) { tab in
+            tabItem(tab, width: layout.tabWidth)
+          }
+
+          if !layout.isOverflowing {
+            plusButton(width: plusButtonWidth)
+          }
+        }
+        .frame(maxWidth: layout.isOverflowing ? .infinity : nil, alignment: .leading)
+        .clipped()
+
+        if layout.isOverflowing {
+          plusButton(width: plusButtonWidth)
+        } else {
+          Spacer(minLength: 0)
+        }
       }
-
-      Image(systemName: "plus")
-        .font(.system(size: 13, weight: .semibold))
-        .foregroundStyle(.iconGray)
-        .frame(width: 56, height: 33)
-
-      Spacer(minLength: 0)
     }
-    .frame(height: 33)
+    .frame(height: 36)
     .background(Color.n10)
     .overlay(alignment: .bottom) {
       Divider()
@@ -37,7 +53,37 @@ struct LinkTabBar: View {
 }
 
 private extension LinkTabBar {
-  func tabItem(_ tab: LinkListViewModel.OpenedLinkTab) -> some View {
+  func calculatedLayout(totalWidth: CGFloat, plusButtonWidth: CGFloat) -> (tabWidth: CGFloat, isOverflowing: Bool) {
+    let maxWidth: CGFloat = 208
+    guard !tabs.isEmpty else {
+      return (maxWidth, false)
+    }
+
+    let availableTabsWidth = max(totalWidth - plusButtonWidth, 0)
+    let idealTabsWidth = CGFloat(tabs.count) * maxWidth
+    let isOverflowing = idealTabsWidth > availableTabsWidth
+    guard isOverflowing else {
+      return (maxWidth, false)
+    }
+
+    let dividedWidth = availableTabsWidth / CGFloat(tabs.count)
+
+    return (max(dividedWidth, 1), true)
+  }
+
+  func plusButton(width: CGFloat) -> some View {
+    Button(action: onNewTab) {
+      DesignSystemAsset.macPlus.swiftUIImage
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+        .foregroundStyle(.iconGray)
+        .frame(width: width, height: 14)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+
+  func tabItem(_ tab: LinkListViewModel.OpenedLinkTab, width: CGFloat) -> some View {
     HStack(spacing: 10) {
       Text(tab.title)
         .font(.C1)
@@ -49,15 +95,16 @@ private extension LinkTabBar {
       Button {
         onClose(tab.id)
       } label: {
-        Image(systemName: "xmark")
-          .font(.system(size: 10, weight: .semibold))
+        DesignSystemAsset.macX.swiftUIImage
+          .resizable()
+          .aspectRatio(contentMode: .fit)
           .foregroundStyle(.iconGray)
-          .frame(width: 20, height: 20)
+          .frame(width: 14, height: 14)
       }
       .buttonStyle(.plain)
     }
     .padding(.horizontal, 14)
-    .frame(width: 208, height: 33)
+    .frame(width: width, height: 33)
     .background(tab.id == selectedTabID ? Color.n0 : Color.n10)
     .overlay(alignment: .trailing) {
       Divider()

--- a/TapTap/Projects/MacFeature/LinkListFeature/Sources/ViewModels/LinkListViewModel.swift
+++ b/TapTap/Projects/MacFeature/LinkListFeature/Sources/ViewModels/LinkListViewModel.swift
@@ -34,11 +34,27 @@ public final class LinkListViewModel {
 
   public struct OpenedLinkTab: Identifiable, Equatable {
     public let id: String
+    public let articleID: String?
     public let title: String
 
-    init(article: ArticleItem) {
-      self.id = article.id
+    init(article: ArticleItem, id: String = UUID().uuidString) {
+      self.id = id
+      self.articleID = article.id
       self.title = article.title
+    }
+
+    static func newTab() -> OpenedLinkTab {
+      OpenedLinkTab(
+        id: UUID().uuidString,
+        articleID: nil,
+        title: "새 탭"
+      )
+    }
+
+    private init(id: String, articleID: String?, title: String) {
+      self.id = id
+      self.articleID = articleID
+      self.title = title
     }
   }
 
@@ -57,6 +73,7 @@ public final class LinkListViewModel {
   public private(set) var deleteToast: DeleteToastState?
   public private(set) var openedTabs: [OpenedLinkTab] = []
   public private(set) var selectedTabID: String?
+  public private(set) var isSelectingNewTabArticle: Bool = false
 
   public var isEditing: Bool = false
   public var selectedArticleIDs: Set<String> = [] {
@@ -112,6 +129,10 @@ public final class LinkListViewModel {
   }
 
   public var categoryTitle: String {
+    if isSelectingNewTabArticle {
+      return "전체"
+    }
+
     if isSeeAllSelected {
       return "전체"
     }
@@ -122,8 +143,12 @@ public final class LinkListViewModel {
   }
 
   public var selectedArticle: ArticleItem? {
-    guard let selectedTabID else { return nil }
-    return articles.first { $0.id == selectedTabID }
+    guard
+      let selectedTabID,
+      let articleID = openedTabs.first(where: { $0.id == selectedTabID })?.articleID
+    else { return nil }
+
+    return articles.first { $0.id == articleID }
   }
 
   public func formattedDate(_ date: Date) -> String {
@@ -140,37 +165,74 @@ public final class LinkListViewModel {
   }
 
   public func beginEditing() {
+    isSelectingNewTabArticle = false
     selectedArticleIDs.removeAll()
     isSingleMovePickerPresented = false
     movingArticle = nil
     isEditing = true
   }
 
+  public func beginNewTabSelection() {
+    let tab = OpenedLinkTab.newTab()
+    openedTabs.append(tab)
+    selectedTabID = tab.id
+    isSelectingNewTabArticle = true
+    endEditing()
+    applyFilters()
+  }
+
   public func openArticle(_ article: ArticleItem) {
-    if openedTabs.contains(where: { $0.id == article.id }) {
-      selectedTabID = article.id
+    if let selectedTabID,
+       let selectedIndex = openedTabs.firstIndex(where: { $0.id == selectedTabID }),
+       openedTabs[selectedIndex].articleID == nil {
+      openedTabs[selectedIndex] = OpenedLinkTab(article: article, id: selectedTabID)
+      isSelectingNewTabArticle = false
       return
     }
 
-    openedTabs.append(OpenedLinkTab(article: article))
-    selectedTabID = article.id
+    isSelectingNewTabArticle = false
+
+    if let existingTab = openedTabs.first(where: { $0.articleID == article.id }) {
+      selectedTabID = existingTab.id
+      return
+    }
+
+    let tab = OpenedLinkTab(article: article)
+    openedTabs.append(tab)
+    selectedTabID = tab.id
   }
 
   public func selectTab(_ tabID: String) {
     guard openedTabs.contains(where: { $0.id == tabID }) else { return }
     selectedTabID = tabID
+    isSelectingNewTabArticle = selectedArticle == nil
   }
 
   public func closeTab(_ tabID: String) {
     guard let closingIndex = openedTabs.firstIndex(where: { $0.id == tabID }) else { return }
     openedTabs.remove(at: closingIndex)
 
-    guard selectedTabID == tabID else { return }
+    guard selectedTabID == tabID else {
+      return
+    }
+
     if openedTabs.indices.contains(closingIndex) {
       selectedTabID = openedTabs[closingIndex].id
     } else {
       selectedTabID = openedTabs.last?.id
     }
+    isSelectingNewTabArticle = selectedArticle == nil && selectedTabID != nil
+  }
+
+  public func closeTabs(articleIDs: Set<String>) {
+    let tabIDs = openedTabs
+      .filter { tab in
+        guard let articleID = tab.articleID else { return false }
+        return articleIDs.contains(articleID)
+      }
+      .map(\.id)
+
+    tabIDs.forEach(closeTab)
   }
 
   public func endEditing() {
@@ -183,6 +245,7 @@ public final class LinkListViewModel {
   }
 
   public func handleCategoryContextChange() {
+    isSelectingNewTabArticle = false
     endEditing()
     applyFilters()
   }
@@ -240,7 +303,7 @@ public final class LinkListViewModel {
       isSingleMovePickerPresented = false
     }
 
-    deletedIDs.forEach(closeTab)
+    closeTabs(articleIDs: deletedIDs)
 
     if isEditing {
       endEditing()
@@ -381,7 +444,7 @@ private extension LinkListViewModel {
 
     let filteredArticles: [ArticleItem]
 
-    if isSeeAllSelected || selectedCategoryID == nil {
+    if isSelectingNewTabArticle || isSeeAllSelected || selectedCategoryID == nil {
       filteredArticles = articles
     } else {
       filteredArticles = articles.filter {
@@ -406,18 +469,27 @@ private extension LinkListViewModel {
   func syncOpenedTabs() {
     let articleIDs = Set(articles.map(\.id))
     openedTabs = openedTabs
-      .filter { articleIDs.contains($0.id) }
+      .filter { tab in
+        guard let articleID = tab.articleID else { return true }
+        return articleIDs.contains(articleID)
+      }
       .map { tab in
-        guard let article = articles.first(where: { $0.id == tab.id }) else {
+        guard
+          let articleID = tab.articleID,
+          let article = articles.first(where: { $0.id == articleID })
+        else {
           return tab
         }
-        return OpenedLinkTab(article: article)
+        return OpenedLinkTab(article: article, id: tab.id)
       }
 
-    if let selectedTabID, !articleIDs.contains(selectedTabID) {
+    if let selectedTabID, !openedTabs.contains(where: { $0.id == selectedTabID }) {
       self.selectedTabID = openedTabs.last?.id
     }
+
+    isSelectingNewTabArticle = selectedArticle == nil && selectedTabID != nil
   }
+
 
   private func showMoveToast(
     movedCount: Int,

--- a/TapTap/Projects/MacFeature/LinkListFeature/Sources/Views/LinkListContainerView.swift
+++ b/TapTap/Projects/MacFeature/LinkListFeature/Sources/Views/LinkListContainerView.swift
@@ -39,13 +39,25 @@ public struct LinkListContainerView: View {
   }
   
   public var body: some View {
-    ZStack {
-      if let detailViewModel {
-        detailContent(detailViewModel)
-          .transition(.move(edge: .trailing).combined(with: .opacity))
-      } else {
-        listContent
-          .transition(.opacity)
+    VStack(spacing: 0) {
+      if !viewModel.openedTabs.isEmpty {
+        LinkTabBar(
+          tabs: viewModel.openedTabs,
+          selectedTabID: viewModel.selectedTabID,
+          onSelect: selectTab,
+          onClose: closeTab,
+          onNewTab: beginNewTabSelection
+        )
+      }
+
+      ZStack {
+        if let detailViewModel {
+          detailContent(detailViewModel)
+            .transition(.move(edge: .trailing).combined(with: .opacity))
+        } else {
+          listContent
+            .transition(.opacity)
+        }
       }
     }
     .overlay(alignment: .top) {
@@ -153,22 +165,12 @@ private extension LinkListContainerView {
   }
 
   func detailContent(_ detailViewModel: LinkDetailViewModel) -> some View {
-    VStack(spacing: 0) {
-      if !viewModel.openedTabs.isEmpty {
-        LinkTabBar(
-          tabs: viewModel.openedTabs,
-          selectedTabID: viewModel.selectedTabID,
-          onSelect: selectTab,
-          onClose: closeTab
-        )
+    LinkDetailView(viewModel: detailViewModel)
+      .onChange(of: detailViewModel.isDeleted) { _, isDeleted in
+        guard isDeleted else { return }
+        viewModel.closeTabs(articleIDs: [detailViewModel.article.id])
+        syncDetailViewModel()
       }
-
-      LinkDetailView(viewModel: detailViewModel)
-        .onChange(of: detailViewModel.isDeleted) { _, isDeleted in
-          guard isDeleted else { return }
-          closeTab(detailViewModel.article.id)
-        }
-    }
   }
 
   var multiMovePickerBinding: Binding<Bool> {
@@ -215,6 +217,11 @@ private extension LinkListContainerView {
 
   func closeTab(_ tabID: String) {
     viewModel.closeTab(tabID)
+    syncDetailViewModel()
+  }
+
+  func beginNewTabSelection() {
+    viewModel.beginNewTabSelection()
     syncDetailViewModel()
   }
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #108 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 링크 리스트 상단에 탭바를 추가했습니다.
- 새 탭 버튼을 통해 빈 탭을 생성하고, 링크 선택 시 해당 탭에 링크 상세 화면이 연결되도록 구현했습니다.
- 열린 탭을 선택하거나 닫을 수 있도록 탭 상태 관리 로직을 추가했습니다.
- 같은 링크를 다시 열 때 기존 탭을 재사용하도록 처리했습니다.
- 탭이 많아질 경우 탭 너비를 가용 영역에 맞춰 조정하도록 탭바 레이아웃을 개선했습니다.
- 링크 삭제 시 연결된 열린 탭도 함께 정리되도록 수정했습니다.

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/76f08bcb-0524-4e9d-88e8-6e9bd59047af


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 새 탭 생성 후 링크 선택 시 상세 화면으로 전환되는지 확인
- [x] 열린 탭 선택/닫기 동작 확인
- [x] 같은 링크 재선택 시 중복 탭이 생성되지 않는지 확인
- [x] 링크 삭제 시 관련 탭이 닫히는지 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

  - 탭 ID와 링크 ID를 분리하기 위해 `OpenedLinkTab`에 `articleID`를 추가했습니다.
  - 새 탭 상태에서는 현재 선택된 카테고리와 관계없이 전체 링크 목록을 보여주도록 처리했습니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
- `LinkListViewModel.swift`의 탭 상태 전이 로직
- `LinkTabBar.swift`의 탭 너비 계산 및 새 탭 버튼 배치

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 새 탭을 추가하고 원하는 아티클을 선택할 수 있습니다.
  - 탭이 많아지면 화면 너비에 맞춰 자동으로 정리되고, 새 탭 버튼이 별도로 표시됩니다.
  - 탭 선택 및 새 탭 상태가 필터와 화면 전환에 일관되게 반영됩니다.

- **버그 수정**
  - 아티클 삭제 후 관련 탭과 상세 화면이 올바르게 동기화됩니다.
  - 탭 닫기 및 선택 상태 처리가 개선되었습니다.

- **UI 개선**
  - 탭 닫기 아이콘과 탭 너비 표시가 새 디자인에 맞게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->