### PR TITLE
Design: #112 1차 design QA 반영

### DIFF
--- a/TapTap/Projects/DesignSystem/Sources/macOS/Toast/LinkActionToast.swift
+++ b/TapTap/Projects/DesignSystem/Sources/macOS/Toast/LinkActionToast.swift
@@ -1,31 +1,60 @@
 //
 //  LinkActionToast.swift
-//  MacLinkListFeature
+//  DesignSystem
 //
 //  Created by 이승진 on 4/28/26.
 //
 
+#if os(macOS)
 import SwiftUI
 
-import DesignSystem
-
-/// 링크 이동/삭제 완료 후 사용자 액션을 안내하는 토스트입니다.
-struct LinkActionToast: View {
-  enum Variant {
+/// 링크 이동/삭제 등 액션 완료 후 사용자에게 안내하는 공용 토스트입니다.
+public struct LinkActionToast: View {
+  public enum Variant {
     case move
     case delete
   }
-  
-  let variant: Variant
-  let count: Int
-  let title: String?
-  let duration: TimeInterval
-  let onUndoTap: (() -> Void)?
-  let onCloseTap: () -> Void
-  
+
+  private let variant: Variant
+  private let message: String
+  private let duration: TimeInterval
+  private let onUndoTap: (() -> Void)?
+  private let onCloseTap: () -> Void
+
   @State private var progress: CGFloat = 1
-  
-  var body: some View {
+
+  public init(
+    variant: Variant,
+    message: String,
+    duration: TimeInterval,
+    onUndoTap: (() -> Void)?,
+    onCloseTap: @escaping () -> Void
+  ) {
+    self.variant = variant
+    self.message = message
+    self.duration = duration
+    self.onUndoTap = onUndoTap
+    self.onCloseTap = onCloseTap
+  }
+
+  public init(
+    variant: Variant,
+    count: Int,
+    title: String?,
+    duration: TimeInterval,
+    onUndoTap: (() -> Void)?,
+    onCloseTap: @escaping () -> Void
+  ) {
+    self.init(
+      variant: variant,
+      message: Self.defaultMessage(variant: variant, count: count, title: title),
+      duration: duration,
+      onUndoTap: onUndoTap,
+      onCloseTap: onCloseTap
+    )
+  }
+
+  public var body: some View {
     HStack(spacing: 0) {
       Text(message)
         .font(.H4_SB)
@@ -33,7 +62,7 @@ struct LinkActionToast: View {
         .lineLimit(1)
         .truncationMode(.tail)
         .padding(.leading, 36)
-      
+
       Spacer(minLength: 16)
 
       if let onUndoTap {
@@ -48,7 +77,7 @@ struct LinkActionToast: View {
         }
         .buttonStyle(.plain)
       }
-      
+
       Button {
         onCloseTap()
       } label: {
@@ -82,21 +111,6 @@ struct LinkActionToast: View {
 }
 
 private extension LinkActionToast {
-  var message: String {
-    switch variant {
-    case .move:
-      if count == 1, let title {
-        return "링크를 \(title)\(roPostposition(for: title)) 이동했어요"
-      }
-      return "\(count)개의 링크를 이동했어요"
-    case .delete:
-      if count == 1, let title {
-        return "'\(title)'을 삭제했어요"
-      }
-      return "\(count)개의 링크를 삭제했어요"
-    }
-  }
-
   var tintColor: Color {
     switch variant {
     case .move:
@@ -105,7 +119,7 @@ private extension LinkActionToast {
       return .danger
     }
   }
-  
+
   var backgroundColor: Color {
     switch variant {
     case .move:
@@ -127,7 +141,22 @@ private extension LinkActionToast {
     }
   }
 
-  func roPostposition(for text: String) -> String {
+  static func defaultMessage(variant: Variant, count: Int, title: String?) -> String {
+    switch variant {
+    case .move:
+      if count == 1, let title {
+        return "링크를 \(title)\(roPostposition(for: title)) 이동했어요"
+      }
+      return "\(count)개의 링크를 이동했어요"
+    case .delete:
+      if count == 1, let title {
+        return "'\(title)'을 삭제했어요"
+      }
+      return "\(count)개의 링크를 삭제했어요"
+    }
+  }
+
+  static func roPostposition(for text: String) -> String {
     guard let scalar = text.unicodeScalars.last else { return "으로" }
     let value = scalar.value
     guard (0xAC00...0xD7A3).contains(value) else { return "으로" }
@@ -137,6 +166,7 @@ private extension LinkActionToast {
   }
 }
 
+#if DEBUG
 #Preview {
   VStack(spacing: 16) {
     LinkActionToast(
@@ -147,7 +177,7 @@ private extension LinkActionToast {
       onUndoTap: {},
       onCloseTap: {}
     )
-    
+
     LinkActionToast(
       variant: .delete,
       count: 3,
@@ -159,3 +189,6 @@ private extension LinkActionToast {
   }
   .padding()
 }
+#endif
+
+#endif

--- a/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Components/Highlight/HighlightCommentView.swift
+++ b/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Components/Highlight/HighlightCommentView.swift
@@ -112,12 +112,12 @@ private struct HighlightCommentBlock: View {
       .background(Color.n20)
       .overlay {
         if isHovered {
-          RoundedRectangle(cornerRadius: 6)
+          RoundedRectangle(cornerRadius: 8)
             .fill(Color.bgDimHover)
         }
       }
-      .clipShape(RoundedRectangle(cornerRadius: 6))
-      .contentShape(RoundedRectangle(cornerRadius: 6))
+      .clipShape(RoundedRectangle(cornerRadius: 12))
+      .contentShape(RoundedRectangle(cornerRadius: 12))
       .onHover { hovering in
         isHovered = hovering
       }

--- a/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Components/Highlight/HighlightEmptyView.swift
+++ b/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Components/Highlight/HighlightEmptyView.swift
@@ -14,7 +14,7 @@ struct HighlightEmptyView: View {
 
   var body: some View {
     VStack(alignment: .center, spacing: 10) {
-      DesignSystemAsset.macEmptyImage.swiftUIImage
+      DesignSystemAsset.emptyImage.swiftUIImage
         .resizable()
         .scaledToFit()
         .frame(width: 160, height: 160)

--- a/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Components/Highlight/HighlightItemView.swift
+++ b/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Components/Highlight/HighlightItemView.swift
@@ -150,8 +150,8 @@ private struct HighlightSentenceBlock: View {
             .fill(Color.bgDimHover)
         }
       }
-      .clipShape(RoundedRectangle(cornerRadius: 8))
-      .contentShape(RoundedRectangle(cornerRadius: 8))
+      .clipShape(RoundedRectangle(cornerRadius: 12))
+      .contentShape(RoundedRectangle(cornerRadius: 12))
       .fixedSize(horizontal: false, vertical: true)
       .onHover { hovering in
         isHovered = hovering

--- a/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Components/LinkDetail/LinkDetailToolbar.swift
+++ b/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Components/LinkDetail/LinkDetailToolbar.swift
@@ -79,10 +79,20 @@ private extension LinkDetailToolbar {
         .resizable()
         .frame(width: 24, height: 24)
       
-      Text("\(categoryName) / \(title)")
-        .font(.B1_M)
-        .foregroundStyle(.text1)
-        .lineLimit(1)
+      HStack(spacing: 0) {
+        Text("\(categoryName)  ")
+          .font(.B1_M)
+          .foregroundStyle(.text1)
+          .lineLimit(1)
+        Text("/")
+          .font(.B1_M)
+          .foregroundStyle(.caption3)
+          .lineLimit(1)
+        Text("  \(title)")
+          .font(.B1_M)
+          .foregroundStyle(.text1)
+          .lineLimit(1)
+      }
     }
   }
 }

--- a/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/ViewModels/LinkDetailViewModel.swift
+++ b/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/ViewModels/LinkDetailViewModel.swift
@@ -22,9 +22,11 @@ public final class LinkDetailViewModel {
   public var draftCommentText: String = ""
   public private(set) var isDeleted: Bool = false
   public private(set) var toastMessage: String?
+  public private(set) var deleteToastMessage: String?
 
   @ObservationIgnored private var persistence: (any LinkDetailPersistence)?
   @ObservationIgnored private var toastDismissTask: Task<Void, Never>?
+  @ObservationIgnored private var deleteToastDismissTask: Task<Void, Never>?
 
   public init(
     article: ArticleItem,
@@ -37,6 +39,7 @@ public final class LinkDetailViewModel {
 
   deinit {
     toastDismissTask?.cancel()
+    deleteToastDismissTask?.cancel()
   }
 
   public var highlights: [HighlightItem] {
@@ -67,7 +70,11 @@ public final class LinkDetailViewModel {
     guard nextMemo != article.userMemo else { return }
 
     article.userMemo = nextMemo
-    saveChanges(successMessage: showsToast ? "메모를 저장했어요" : nil)
+    saveChanges {
+      if showsToast {
+        showToast("메모를 저장했어요")
+      }
+    }
   }
 
   public func deleteArticle() {
@@ -81,7 +88,6 @@ public final class LinkDetailViewModel {
       persistence.delete(article)
       try persistence.save()
       isDeleted = true
-      showToast("링크를 삭제했어요")
     } catch {
       showToast("삭제하지 못했어요")
       print("delete link failed: \(error)")
@@ -145,7 +151,7 @@ public final class LinkDetailViewModel {
     commentEditingTarget = nil
     draftCommentType = ""
     draftCommentText = ""
-    saveChanges(successMessage: nil)
+    saveChanges()
   }
 
   public func deleteComment(
@@ -157,7 +163,9 @@ public final class LinkDetailViewModel {
       commentEditingTarget = nil
       draftCommentText = ""
     }
-    saveChanges(successMessage: "메모를 삭제했어요")
+    saveChanges {
+      showDeleteToast("메모를 삭제했어요")
+    }
   }
 
   public func deleteHighlight(_ highlightID: String) {
@@ -169,7 +177,9 @@ public final class LinkDetailViewModel {
 
     article.highlights?.removeAll { $0.id == highlightID }
     persistence?.delete(highlight)
-    saveChanges(successMessage: "하이라이트를 삭제했어요")
+    saveChanges {
+      showDeleteToast("하이라이트를 삭제했어요")
+    }
   }
 
   public func hideToast() {
@@ -177,15 +187,19 @@ public final class LinkDetailViewModel {
     toastDismissTask = nil
     toastMessage = nil
   }
+
+  public func hideDeleteToast() {
+    deleteToastDismissTask?.cancel()
+    deleteToastDismissTask = nil
+    deleteToastMessage = nil
+  }
 }
 
 private extension LinkDetailViewModel {
-  func saveChanges(successMessage: String?) {
+  func saveChanges(onSuccess: () -> Void = {}) {
     do {
       try persistence?.save()
-      if let successMessage {
-        showToast(successMessage)
-      }
+      onSuccess()
     } catch {
       showToast("저장하지 못했어요")
       print("save link detail failed: \(error)")
@@ -201,6 +215,19 @@ private extension LinkDetailViewModel {
       guard !Task.isCancelled else { return }
       await MainActor.run {
         hideToast()
+      }
+    }
+  }
+
+  func showDeleteToast(_ message: String) {
+    deleteToastDismissTask?.cancel()
+    deleteToastMessage = message
+
+    deleteToastDismissTask = Task {
+      try? await Task.sleep(for: .seconds(3))
+      guard !Task.isCancelled else { return }
+      await MainActor.run {
+        hideDeleteToast()
       }
     }
   }

--- a/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Views/LinkDetailView.swift
+++ b/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Views/LinkDetailView.swift
@@ -61,6 +61,19 @@ public struct LinkDetailView: View {
         .zIndex(20)
       }
 
+      if let deleteToastMessage = viewModel.deleteToastMessage {
+        LinkActionToast(
+          variant: .delete,
+          message: deleteToastMessage,
+          duration: 3,
+          onUndoTap: nil,
+          onCloseTap: viewModel.hideDeleteToast
+        )
+        .padding(.horizontal, 30)
+        .padding(.top, 32)
+        .zIndex(20)
+      }
+
       if let deleteTarget {
         MacAlertDialog(
           title: deleteTarget.alertTitle,
@@ -82,6 +95,7 @@ public struct LinkDetailView: View {
       }
     }
     .animation(.easeInOut(duration: 0.2), value: viewModel.toastMessage)
+    .animation(.easeInOut(duration: 0.2), value: viewModel.deleteToastMessage)
     .animation(.easeInOut(duration: 0.2), value: isMemoPanelPresented)
   }
 }

--- a/TapTap/Projects/MacFeature/LinkListFeature/Sources/Components/LinkTabBar.swift
+++ b/TapTap/Projects/MacFeature/LinkListFeature/Sources/Components/LinkTabBar.swift
@@ -84,7 +84,9 @@ private extension LinkTabBar {
   }
 
   func tabItem(_ tab: LinkListViewModel.OpenedLinkTab, width: CGFloat) -> some View {
-    HStack(spacing: 10) {
+    let isSelected = tab.id == selectedTabID
+
+    return HStack(spacing: 10) {
       Text(tab.title)
         .font(.C1)
         .foregroundStyle(.text1)
@@ -92,22 +94,26 @@ private extension LinkTabBar {
 
       Spacer(minLength: 8)
 
-      Button {
-        onClose(tab.id)
-      } label: {
-        DesignSystemAsset.macX.swiftUIImage
-          .resizable()
-          .aspectRatio(contentMode: .fit)
-          .foregroundStyle(.iconGray)
-          .frame(width: 14, height: 14)
+      if isSelected {
+        Button {
+          onClose(tab.id)
+        } label: {
+          DesignSystemAsset.macX.swiftUIImage
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .foregroundStyle(.iconGray)
+            .frame(width: 14, height: 14)
+        }
+        .buttonStyle(.plain)
       }
-      .buttonStyle(.plain)
     }
     .padding(.horizontal, 14)
-    .frame(width: width, height: 33)
-    .background(tab.id == selectedTabID ? Color.n0 : Color.n10)
+    .frame(width: width, height: 36)
+    .background(isSelected ? Color.n0 : Color.n10)
     .overlay(alignment: .trailing) {
-      Divider()
+      Rectangle()
+        .fill(Color.divider2)
+        .frame(width: 1)
     }
     .contentShape(Rectangle())
     .onTapGesture {

--- a/TapTap/Projects/MacFeature/LinkListFeature/Sources/ViewModels/LinkListViewModel.swift
+++ b/TapTap/Projects/MacFeature/LinkListFeature/Sources/ViewModels/LinkListViewModel.swift
@@ -32,6 +32,11 @@ public final class LinkListViewModel {
     public let linkTitle: String?
   }
 
+  public struct ArticleDeleteToastState: Identifiable {
+    public let id = UUID()
+    public let message: String
+  }
+
   public struct OpenedLinkTab: Identifiable, Equatable {
     public let id: String
     public let articleID: String?
@@ -47,7 +52,7 @@ public final class LinkListViewModel {
       OpenedLinkTab(
         id: UUID().uuidString,
         articleID: nil,
-        title: "새 탭"
+        title: "모든 링크"
       )
     }
 
@@ -71,6 +76,7 @@ public final class LinkListViewModel {
   public private(set) var movingArticle: ArticleItem?
   public private(set) var moveToast: MoveToastState?
   public private(set) var deleteToast: DeleteToastState?
+  public private(set) var articleDeleteToast: ArticleDeleteToastState?
   public private(set) var openedTabs: [OpenedLinkTab] = []
   public private(set) var selectedTabID: String?
   public private(set) var isSelectingNewTabArticle: Bool = false
@@ -98,12 +104,14 @@ public final class LinkListViewModel {
 
   @ObservationIgnored private var moveToastDismissTask: Task<Void, Never>?
   @ObservationIgnored private var deleteToastDismissTask: Task<Void, Never>?
+  @ObservationIgnored private var articleDeleteToastDismissTask: Task<Void, Never>?
 
   public init() {}
 
   deinit {
     moveToastDismissTask?.cancel()
     deleteToastDismissTask?.cancel()
+    articleDeleteToastDismissTask?.cancel()
   }
 
   public func updatePersistence(_ persistence: any LinkListPersistence) {
@@ -430,6 +438,25 @@ public final class LinkListViewModel {
       hideMoveToast()
       applyFilters()
     }
+  }
+
+  public func showArticleDeleteToast(title: String) {
+    articleDeleteToastDismissTask?.cancel()
+    articleDeleteToast = ArticleDeleteToastState(message: "'\(title)'을 삭제했어요")
+
+    articleDeleteToastDismissTask = Task {
+      try? await Task.sleep(for: .seconds(3))
+      guard !Task.isCancelled else { return }
+      await MainActor.run {
+        hideArticleDeleteToast()
+      }
+    }
+  }
+
+  public func hideArticleDeleteToast() {
+    articleDeleteToastDismissTask?.cancel()
+    articleDeleteToastDismissTask = nil
+    articleDeleteToast = nil
   }
 
   public func dismiss() {

--- a/TapTap/Projects/MacFeature/LinkListFeature/Sources/Views/LinkListContainerView.swift
+++ b/TapTap/Projects/MacFeature/LinkListFeature/Sources/Views/LinkListContainerView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 import Core
+import DesignSystem
 import MacLinkDetailFeature
 import SwiftData
 
@@ -85,6 +86,17 @@ public struct LinkListContainerView: View {
           )
           .transition(.move(edge: .top).combined(with: .opacity))
         }
+
+        if let articleDeleteToast = viewModel.articleDeleteToast {
+          LinkActionToast(
+            variant: .delete,
+            message: articleDeleteToast.message,
+            duration: 3,
+            onUndoTap: nil,
+            onCloseTap: viewModel.hideArticleDeleteToast
+          )
+          .transition(.move(edge: .top).combined(with: .opacity))
+        }
       }
       .padding(.horizontal, 40)
       .padding(.top, 20)
@@ -92,6 +104,7 @@ public struct LinkListContainerView: View {
     }
     .animation(.easeInOut(duration: 0.2), value: viewModel.moveToast?.id)
     .animation(.easeInOut(duration: 0.2), value: viewModel.deleteToast?.id)
+    .animation(.easeInOut(duration: 0.2), value: viewModel.articleDeleteToast?.id)
     .onAppear {
       viewModel.updatePersistence(SwiftDataLinkListPersistence(modelContext: modelContext))
       updateViewModel()
@@ -162,12 +175,14 @@ private extension LinkListContainerView {
         )
       }
     }
+    .padding(.top, 10)
   }
 
   func detailContent(_ detailViewModel: LinkDetailViewModel) -> some View {
     LinkDetailView(viewModel: detailViewModel)
       .onChange(of: detailViewModel.isDeleted) { _, isDeleted in
         guard isDeleted else { return }
+        viewModel.showArticleDeleteToast(title: detailViewModel.article.title)
         viewModel.closeTabs(articleIDs: [detailViewModel.article.id])
         syncDetailViewModel()
       }


### PR DESCRIPTION
## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #112

---

### 🧶 주요 변경 내용 (Summary)

- 링크 상세 브레드크럼(`카테고리 / 제목`)의 `/` 구분자 색상을 텍스트와 분리 (`caption3`)
- 새 탭 기본 타이틀을 "새 탭" → "모든 링크"로 변경
- 링크 탭바(LinkTabBar) 디자인 QA 반영
  - × 닫기 버튼은 선택된 탭에서만 노출
  - 탭 사이 구분선을 항상 노출하도록 수정, `Divider()`가 `.overlay`에서 방향을 못 잡고 가로선으로 렌더링되던 버그 수정
  - 탭 높이를 컨테이너 높이(36pt)에 맞춰 구분선이 바텀 라인까지 이어지도록 수정
- 탭바-콘텐츠 사이 간격 조정 (리스트 화면에는 10pt 여백 추가, 디테일 화면은 탭바에 바로 붙도록 유지)
- 링크/하이라이트/메모 삭제 완료 토스트를 `LinkActionToast`로 통일
  - `LinkActionToast`를 LinkListFeature에서 DesignSystem으로 승격 (macOS 공용 컴포넌트)
  - 삭제 확인 알럿(`MacAlertDialog`)은 그대로 유지, 삭제 후 안내 토스트만 스타일 통일 (실행취소 없음 — 삭제는 복구 불가)
  - 링크(article) 전체 삭제 시 상세 화면이 즉시 닫혀 토스트가 안 보이던 문제 수정 → 리스트 화면으로 돌아온 뒤 토스트 노출

---

### 📸 스크린샷 (Optional)
<img width="1641" height="844" alt="image" src="https://github.com/user-attachments/assets/c785b2fc-f520-4fb4-889c-229c242a75fb" />

---

### 🧪 테스트 / 검증 내역

- [x] MacLinkListFeature, MacLinkDetailFeature 빌드 성공 확인
- [x] Xcode에서 실제 화면 동작 확인

---

### 💬 기타 공유 사항

- 링크 삭제는 알럿 문구상 "복구할 수 없다"고 안내하고 있어 토스트에 실행취소 버튼은 넣지 않았습니다. 필요하면 후속으로 pending-delete 방식 도입 검토 가능합니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)

- `LinkTabBar.swift`의 구분선 표시 로직 (`showsDivider` → 항상 표시로 단순화)
- `LinkDetailViewModel.swift`의 `saveChanges` 시그니처 변경 (`successMessage: String?` → `onSuccess: () -> Void`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 삭제 작업 후 별도 삭제 토스트가 표시되며, 닫기 기능을 제공합니다.
  * 토스트 컴포넌트가 다양한 메시지를 직접 표시할 수 있도록 개선되었습니다.
  * 선택된 탭에서만 닫기 버튼이 표시됩니다.
  * 새 탭의 이름이 “모든 링크”로 변경되었습니다.

* **개선 사항**
  * 하이라이트 영역의 모서리 라운딩과 호버 표시가 조정되었습니다.
  * 링크 상세 화면의 경로 표시와 빈 상태 이미지가 개선되었습니다.
  * 삭제 및 저장 관련 토스트 표시 흐름이 더욱 일관되게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->