### PR TITLE
Fix: #116 사이드바수정

### DIFF
--- a/TapTap/Projects/DesignSystem/Sources/macOS/Alert/MacAlertDialog.swift
+++ b/TapTap/Projects/DesignSystem/Sources/macOS/Alert/MacAlertDialog.swift
@@ -30,6 +30,7 @@ public struct MacAlertDialog: View {
   private let message: String
   private let cancelTitle: String
   private let destructiveTitle: String
+  private let width: CGFloat
   private let onCancel: () -> Void
   private let onDestructive: () -> Void
 
@@ -38,6 +39,7 @@ public struct MacAlertDialog: View {
     message: String,
     cancelTitle: String = "취소",
     destructiveTitle: String = "삭제",
+    width: CGFloat = 560,
     onCancel: @escaping () -> Void,
     onDestructive: @escaping () -> Void
   ) {
@@ -45,6 +47,7 @@ public struct MacAlertDialog: View {
     self.message = message
     self.cancelTitle = cancelTitle
     self.destructiveTitle = destructiveTitle
+    self.width = width
     self.onCancel = onCancel
     self.onDestructive = onDestructive
   }
@@ -91,7 +94,7 @@ public struct MacAlertDialog: View {
       .padding(.horizontal, 20)
       .padding(.top, 20)
       .padding(.bottom, 20)
-      .frame(width: 560, height: 160)
+      .frame(width: width, height: 160)
       .background(Color.background)
       .clipShape(RoundedRectangle(cornerRadius: 16))
       .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 0)

--- a/TapTap/Projects/TapTapMac/Sources/RootView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/RootView.swift
@@ -42,6 +42,7 @@ struct RootView: View {
   private let sidebarCollapseThreshold: CGFloat = 860
   
   @State private var isSettingAlertPresented: Bool = false
+  @State private var categoryPendingDeletion: UUID?
   
   var body: some View {
     GeometryReader { geometry in
@@ -93,13 +94,7 @@ struct RootView: View {
               selectedCategoryID = nil
               selectedDetail = .addLink
             },
-            onSeeAllLinks: {
-              selectedDetail = .linkList
-              isSaveSuccessToastPresented = false
-              isSeeAllSelected = true
-              selectedCategoryID = nil
-              searchViewModel.clearSearch()
-            },
+            onSeeAllLinks: showAllLinks,
             onAddCategory: showAddCategoryPopover,
             onSelectCategory: { category in
               selectedDetail = .linkList
@@ -109,7 +104,7 @@ struct RootView: View {
               searchViewModel.clearSearch()
             },
             onToggleCategoryFavorite: toggleCategoryFavorite,
-            onDeleteCategory: deleteCategory,
+            onDeleteCategory: { categoryPendingDeletion = $0 },
             onSettings: {
               print("tap")
               isSettingAlertPresented = true
@@ -178,6 +173,22 @@ struct RootView: View {
             .padding(.horizontal, currentWidth < 600 ? 20 : 0)
             .padding(.vertical, currentHeight < 640 ? 20 : 0)
             .zIndex(30)
+        }
+      }
+      .overlay {
+        if let category = categoryPendingDeletion.flatMap(category(id:)) {
+          // MacAlertDialog가 배경 딤을 자체적으로 그리므로 별도 딤 레이어는 두지 않는다.
+          MacAlertDialog(
+            title: "이 카테고리를 삭제할까요?",
+            message: deleteCategoryMessage(for: category),
+            width: 536,
+            onCancel: { categoryPendingDeletion = nil },
+            onDestructive: {
+              categoryPendingDeletion = nil
+              deleteCategory(category.id)
+            }
+          )
+          .zIndex(40)
         }
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -322,6 +333,17 @@ struct RootView: View {
     }
   }
   
+  private func category(id: UUID) -> CategoryItem? {
+    allCategories.first { $0.id == id }
+  }
+
+  /// 카테고리를 지워도 링크는 사라지지 않고 미분류(전체)로 옮겨진다.
+  /// `CategoryCommand.deleteCategory(id:)`가 링크의 `category`를 nil로 만드는 동작과 대응한다.
+  private func deleteCategoryMessage(for category: CategoryItem) -> String {
+    let linkCount = (category.links ?? []).count
+    return "‘\(category.categoryName)’ 카테고리와 \(linkCount)개의 링크가 삭제되며, 포함된 링크는 전체로 이동돼요"
+  }
+
   private func deleteCategory(_ categoryID: UUID) {
     do {
       if selectedCategoryID == categoryID {
@@ -336,14 +358,37 @@ struct RootView: View {
     }
   }
   
+  @ViewBuilder
   private var detailContent: some View {
-    LinkListContainerView(
-      articles: articles,
-      categories: allCategories,
-      selectedCategoryID: selectedCategoryID,
-      isSeeAllSelected: isSeeAllSelected,
-      isEditing: $isLinkListEditing
-    )
+    switch selectedDetail {
+    case .linkList:
+      LinkListContainerView(
+        articles: articles,
+        categories: allCategories,
+        selectedCategoryID: selectedCategoryID,
+        isSeeAllSelected: isSeeAllSelected,
+        isEditing: $isLinkListEditing
+      )
+
+    case .addLink:
+      // AddLinkView는 자체 상단바("링크 추가하기" + 추가 버튼)를 그리므로
+      // contentStack에서 MacToolbar를 숨긴 상태(selectedDetail != .linkList)로 들어온다.
+      AddLinkView(
+        categories: allCategories,
+        totalLinkCount: articles.count,
+        onSave: showSavedLink,
+        onShowExistingLink: showAllLinks,
+        onAddCategory: showAddCategoryPopover
+      )
+    }
+  }
+
+  private func showAllLinks() {
+    selectedDetail = .linkList
+    isSaveSuccessToastPresented = false
+    isSeeAllSelected = true
+    selectedCategoryID = nil
+    searchViewModel.clearSearch()
   }
   
   private func showSavedLink(_ article: ArticleItem) {

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarView.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/MacSidebarView.swift
@@ -116,23 +116,30 @@ public struct MacSidebarView: View {
       .padding(.bottom, 20)
       .zIndex(2)
 
+      // 카테고리 목록 위에 얹혀 하단으로 스크롤되는 행을 흐리게 없앤다.
+      // 반드시 콘텐츠(zIndex 2)보다 위, 설정 버튼(zIndex 4)보다 아래여야 보인다.
       VStack {
         Spacer()
         LinearGradient(
-          colors: [Color.bgButtonGrad4, Color.n0],
-          startPoint: .top,
-          endPoint: .bottom
+          stops: [
+            Gradient.Stop(color: .bgButtonGrad4, location: 0.0),
+            Gradient.Stop(color: .n0, location: 0.7)
+          ],
+          startPoint: UnitPoint(x: 0.44, y: 0),
+          endPoint: UnitPoint(x: 0.44, y: 1)
         )
         .frame(height: 72)
-        .allowsHitTesting(false)
+        .blur(radius: 4)
       }
-      .zIndex(1)
+      .clipShape(sidebarShape)
+      .allowsHitTesting(false)
+      .zIndex(3)
 
       if !isCollapsed {
         SidebarSettingsButton(onSettings: onSettings)
           .padding(.leading, 20)
           .padding(.bottom, 20)
-          .zIndex(3)
+          .zIndex(4)
       }
     }
     .frame(width: width, alignment: .leading)

--- a/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategorySectionHeader.swift
+++ b/TapTap/Projects/TapTapMac/Sources/Sidebar/SidebarCategorySectionHeader.swift
@@ -12,17 +12,19 @@ struct SidebarCategorySectionHeader: View {
 
   var body: some View {
     ZStack(alignment: .top) {
-      HStack {
-        Spacer()
-        LinearGradient(
-          colors: [Color.bgButtonGrad4.opacity(0), Color.n0.opacity(0.25)],
-          startPoint: .bottom,
-          endPoint: .top
-        )
-        .frame(width: 240, height: 48)
-        .rotationEffect(.degrees(180))
-        Spacer()
-      }
+      // 스티키 "카테고리" 헤더 뒤 스크림. 위쪽은 완전 흰색이라 스크롤되는 행이
+      // 헤더에 닿기 전에 사라지고, 아래로 투명해져 그 밑 행은 정상적으로 보인다.
+      LinearGradient(
+        stops: [
+          Gradient.Stop(color: .n0, location: 0.0),
+          Gradient.Stop(color: .n0, location: 0.75),
+          Gradient.Stop(color: .bgButtonGrad4, location: 1.0)
+        ],
+        startPoint: .top,
+        endPoint: .bottom
+      )
+      .frame(maxWidth: .infinity)
+      .frame(height: 48)
       .offset(y: -6)
 
       HStack {


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)

- Closes #116 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- [x] 카테고리 알럿 + 토스트 추가
- [x] 카테고리 이동하기 그라데이션 구현
- [x] 사이드바 링크추가 버튼 연결

---

### 📸 스크린샷 (Optional)

<img width="1392" height="809" alt="스크린샷 2026-07-28 20 34 46" src="https://github.com/user-attachments/assets/34c1f1ec-c858-4387-8909-cd321585b6c7" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] Mac OS 26.0 환경에서 정상 동작

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 카테고리 삭제 전 확인 다이얼로그를 표시합니다.
  * macOS 알림 다이얼로그의 너비를 설정할 수 있습니다.
  * 링크 목록과 링크 추가 화면 간 전환을 지원합니다.

* **버그 수정**
  * 사이드바 스크롤 영역의 페이드 효과와 설정 버튼 표시 순서를 개선했습니다.

* **UI 개선**
  * 사이드바와 카테고리 헤더의 그라데이션 및 페이드 표시를 자연스럽게 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->