### PR TITLE
✨ Feat: #125 macOS 사파리 익스텐션 추가

### DIFF
--- a/TapTap/Projects/App/SafariExtension/Resources/background.js
+++ b/TapTap/Projects/App/SafariExtension/Resources/background.js
@@ -13,5 +13,16 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
       });
     return true;
   }
+  if (message.action == "syncHighlights") {
+    browser.runtime.sendNativeMessage("com.Nbs.dev.ADA.app", message)
+      .then(response => {
+        sendResponse(response);
+      })
+      .catch(error => {
+        console.error("background.js: 하이라이트 동기화 오류:", error);
+        sendResponse({ error: error.message });
+      });
+    return true;
+  }
   return false;
 });

--- a/TapTap/Projects/App/SafariExtension/Resources/gesture.js
+++ b/TapTap/Projects/App/SafariExtension/Resources/gesture.js
@@ -11,15 +11,25 @@ TapTap.gesture = {
   
   init: function() {
     document.addEventListener('touchend', this.handleTouchEnd.bind(this), false);
+    if (!('ontouchend' in window)) {
+      document.addEventListener('dblclick', this.handleDoubleTap.bind(this), false);
+    }
   },
-  
+
   handleTouchEnd: function(event) {
     const currentTime = new Date().getTime();
     const timeSinceLastTap = currentTime - this.lastTapTime;
-    
+
     if (timeSinceLastTap < 300 && timeSinceLastTap > 0) {
+      this.handleDoubleTap(event);
+    }
+
+    this.lastTapTime = currentTime;
+  },
+
+  handleDoubleTap: function(event) {
       console.log("더블탭 감지됨");
-      
+
       const wrapper = event.target.closest('.taptap-wrapper');
       
       if (wrapper) {
@@ -66,9 +76,6 @@ TapTap.gesture = {
         TapTap.sentence.selectSentenceAt(event);
         event.preventDefault();
       }
-    }
-    
-    this.lastTapTime = currentTime;
   }
 };
 

--- a/TapTap/Projects/App/SafariExtension/Resources/highlight.js
+++ b/TapTap/Projects/App/SafariExtension/Resources/highlight.js
@@ -170,6 +170,9 @@ TapTap.highlight = {
 
     // 3. 기존 하이라이트 삭제 (이제 Range가 깨져도 상관없음)
     this.removeHighlight(id);
+
+    const staleCapsuleContainer = document.getElementById('capsules-for-' + id);
+    if (staleCapsuleContainer) staleCapsuleContainer.remove();
     
     // 4. 새 하이라이트의 ID를 원본 ID로 교체 및 메모 복구
     const newWrapper = this.getHighlightElementById(tempId);
@@ -385,5 +388,40 @@ TapTap.highlight = {
       document.body.appendChild(sharedDiv);
     }
     sharedDiv.textContent = JSON.stringify(highlights);
+
+    if (!('ontouchend' in window)) {
+      clearTimeout(this._syncTimer);
+      this._syncTimer = setTimeout(() => {
+        browser.runtime.sendMessage({
+          action: 'syncHighlights',
+          url: window.location.href,
+          title: document.title,
+          imageURL: this._extractThumbnailImage(),
+          highlights: highlights
+        }).catch(() => {});
+      }, 300);
+    }
+  },
+
+  _extractThumbnailImage: function() {
+    const ogImage = document.querySelector('meta[property="og:image"]');
+    if (ogImage && ogImage.content) return ogImage.content;
+
+    const twitterImage = document.querySelector('meta[name="twitter:image"]');
+    if (twitterImage && twitterImage.content) return twitterImage.content;
+
+    const appleIcon = document.querySelector('link[rel="apple-touch-icon"]');
+    if (appleIcon && appleIcon.href) return appleIcon.href;
+
+    const favicon = document.querySelector('link[rel="icon"]');
+    if (favicon && favicon.href) return favicon.href;
+
+    const images = Array.from(document.querySelectorAll('img'));
+    if (images.length > 0) {
+      images.sort((a, b) => (b.naturalWidth * b.naturalHeight) - (a.naturalWidth * a.naturalHeight));
+      if (images[0].src) return images[0].src;
+    }
+
+    return "";
   }
 };

--- a/TapTap/Projects/App/SafariExtension/Resources/manifest.json
+++ b/TapTap/Projects/App/SafariExtension/Resources/manifest.json
@@ -31,5 +31,5 @@
       "default_icon": "images/toolbar-icon.svg"
   },
 
-  "permissions": ["storage"]
+  "permissions": ["storage", "nativeMessaging"]
 }

--- a/TapTap/Projects/App/SafariExtension/Resources/memo.js
+++ b/TapTap/Projects/App/SafariExtension/Resources/memo.js
@@ -30,6 +30,8 @@ TapTap.memo = {
   },
 
   handleExternalClick: function(event) {
+    if (TapTap.tooltip?._suppressClickUntil && Date.now() < TapTap.tooltip._suppressClickUntil) return;
+
     if (this.memoUIElement.style.display === 'flex' && !this.memoUIElement.contains(event.target)) {
         this.hideMemoInput();
     }
@@ -140,6 +142,9 @@ TapTap.memo = {
       textarea.focus();
     }
     this.memoUIElement.style.display = 'flex';
+    if (textarea && !('ontouchend' in window)) {
+      textarea.focus();
+    }
   },
 
   hideMemoInput: function() {
@@ -165,7 +170,7 @@ TapTap.memo = {
 
     let memoToSave;
     if (memoId) {
-      memoToSave = highlight.memos.find(m => m.id === memoId);
+      memoToSave = highlight.memos.find(m => String(m.id) === String(memoId));
       if (memoToSave) {
         memoToSave.text = memoText;
       }
@@ -189,7 +194,7 @@ TapTap.memo = {
       const highlight = highlights.find(h => h.id === highlightId);
 
       if (highlight && highlight.memos) {
-          highlight.memos = highlight.memos.filter(m => m.id !== memoId);
+          highlight.memos = highlight.memos.filter(m => String(m.id) !== String(memoId));
           localStorage.setItem(pageKey, JSON.stringify(highlights));
           TapTap.highlight._updateSharedDom(highlights); // DOM에 데이터 저장
       }

--- a/TapTap/Projects/App/SafariExtension/Resources/sentence.js
+++ b/TapTap/Projects/App/SafariExtension/Resources/sentence.js
@@ -8,9 +8,9 @@
 window.TapTap = window.TapTap || {};
 TapTap.sentence = {
   selectSentenceAt: function(event) {
-    const touch = event.changedTouches[0];
-    const x = touch.clientX;
-    const y = touch.clientY;
+    const point = event.changedTouches ? event.changedTouches[0] : event;
+    const x = point.clientX;
+    const y = point.clientY;
 
     const range = document.caretRangeFromPoint(x, y);
 

--- a/TapTap/Projects/App/SafariExtension/Resources/tooltip.js
+++ b/TapTap/Projects/App/SafariExtension/Resources/tooltip.js
@@ -59,6 +59,10 @@ TapTap.tooltip = {
     event.preventDefault();
     event.stopPropagation();
 
+    if (!('ontouchend' in window)) {
+      this._suppressClickUntil = Date.now() + 400;
+    }
+
     const target = event.target.closest('[data-color], [data-action]');
     if (!target) return;
 
@@ -116,6 +120,8 @@ TapTap.tooltip = {
   },
 
   handleExternalClick: function(event) {
+    if (this._suppressClickUntil && Date.now() < this._suppressClickUntil) return;
+
     const wrapper = event.target.closest('.taptap-wrapper');
     if (wrapper) {
       event.preventDefault();

--- a/TapTap/Projects/App/SafariExtension/Sources/SafariWebExtensionHandler.swift
+++ b/TapTap/Projects/App/SafariExtension/Sources/SafariWebExtensionHandler.swift
@@ -8,7 +8,9 @@
 import SafariServices
 import SwiftData
 
+#if os(iOS)
 import Core
+#endif
 
 final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
   private let appGroupID = "group.com.nbs.dev.ADA.shared"
@@ -58,8 +60,19 @@ final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
       }
       sharedUserDefaults?.set(value, forKey: "hasShownHighlightToast")
       let success = sharedUserDefaults?.synchronize() ?? false
-      
+
       self.sendResponse(to: context, with: ["success": success])
+
+    case "syncHighlights":
+      guard let url = message["url"] as? String else {
+        self.sendResponse(to: context, with: ["error": "URL not provided"])
+        return
+      }
+      let title = message["title"] as? String ?? url
+      let imageURL = message["imageURL"] as? String
+      let drafts = message["highlights"] as? [[String: Any]] ?? []
+      let synced = self.syncHighlights(url: url, title: title, imageURL: imageURL, drafts: drafts)
+      self.sendResponse(to: context, with: ["success": synced])
       
     default:
       self.sendResponse(to: context, with: ["error": "Unknown action"])
@@ -69,6 +82,77 @@ final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
 
 // MARK: - Communication Method
 private extension SafariWebExtensionHandler {
+  func syncHighlights(url urlString: String, title: String, imageURL: String?, drafts: [[String: Any]]) -> Bool {
+    let container = AppGroupContainer.shared
+    let context = ModelContext(container)
+
+    let thumbnailURL = (imageURL?.isEmpty == false) ? imageURL : nil
+    let fetchDescriptor = FetchDescriptor<ArticleItem>(predicate: #Predicate { $0.urlString == urlString })
+    let article: ArticleItem
+    if let existing = try? context.fetch(fetchDescriptor).first {
+      article = existing
+      if article.imageURL?.isEmpty != false, let thumbnailURL {
+        article.imageURL = thumbnailURL
+      }
+    } else {
+      guard !drafts.isEmpty else { return true }
+      article = ArticleItem(urlString: urlString, title: title, imageURL: thumbnailURL)
+      context.insert(article)
+    }
+
+    for highlight in article.highlights ?? [] {
+      context.delete(highlight)
+    }
+
+    var newHighlights: [HighlightItem] = []
+    for draft in drafts {
+      guard let id = draft["id"] as? String,
+            let sentence = draft["text"] as? String,
+            let color = draft["color"] as? String else { continue }
+
+      let commentsArray = draft["memos"] as? [[String: Any]] ?? []
+      let comments = commentsArray.compactMap { dict -> Comment? in
+        guard let commentId = dict["id"] as? Double,
+              let commentText = dict["text"] as? String,
+              let commentType = dict["type"] as? String else { return nil }
+        return Comment(id: commentId, type: commentType, text: commentText)
+      }
+
+      let newHighlight = HighlightItem(
+        id: id,
+        sentence: sentence,
+        type: highlightType(from: color),
+        createdAt: Date(),
+        comments: comments
+      )
+      newHighlight.link = article
+      context.insert(newHighlight)
+      newHighlights.append(newHighlight)
+    }
+    article.highlights = newHighlights
+    article.lastViewedDate = Date()
+
+    do {
+      try context.save()
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  func highlightType(from rgba: String) -> String {
+    switch rgba {
+    case "rgba(255, 85, 249, 0.2)":
+      return "What"
+    case "rgba(255, 241, 39, 0.2)":
+      return "Why"
+    case "rgba(31, 180, 255, 0.2)":
+      return "Detail"
+    default:
+      return "What"
+    }
+  }
+
   func fetchHighlights(for urlString: String) -> Any? {
     let container = AppGroupContainer.shared
     

--- a/TapTap/Projects/DesignSystem/Sources/macOS/Card/MacArticleCard/MacArticleCard+Subviews.swift
+++ b/TapTap/Projects/DesignSystem/Sources/macOS/Card/MacArticleCard/MacArticleCard+Subviews.swift
@@ -56,31 +56,31 @@ extension MacArticleCard {
   }
 
   var articleImage: some View {
-    AsyncImage(url: URL(string: imageURL ?? "")) { phase in
-      switch phase {
-      case .empty:
-        ProgressView()
-          .frame(width: 90, height: 90)
+    Group {
+      if let imageURL, !imageURL.isEmpty, let url = URL(string: imageURL) {
+        AsyncImage(url: url) { phase in
+          switch phase {
+          case .empty:
+            ProgressView()
+              .frame(width: 90, height: 90)
 
-      case .success(let image):
-        image
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .frame(width: 90, height: 90)
-          .clipped()
-          .clipShape(RoundedRectangle(cornerRadius: 8))
+          case .success(let image):
+            image
+              .resizable()
+              .aspectRatio(contentMode: .fill)
+              .frame(width: 90, height: 90)
+              .clipped()
+              .clipShape(RoundedRectangle(cornerRadius: 8))
 
-      case .failure:
-        DesignSystemAsset.notImage.swiftUIImage
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .frame(width: 90, height: 90)
-          .foregroundStyle(.gray)
-          .clipped()
-          .clipShape(RoundedRectangle(cornerRadius: 8))
+          case .failure:
+            faviconFallback
 
-      @unknown default:
-        EmptyView()
+          @unknown default:
+            notImagePlaceholder
+          }
+        }
+      } else {
+        faviconFallback
       }
     }
     .overlay {
@@ -89,6 +89,43 @@ extension MacArticleCard {
           .fill(Color.bgDim)
       }
     }
+  }
+
+  private var faviconFallback: some View {
+    Group {
+      if let faviconURL {
+        AsyncImage(url: faviconURL) { phase in
+          if case .success(let favicon) = phase {
+            favicon
+              .resizable()
+              .aspectRatio(contentMode: .fit)
+              .frame(width: 40, height: 40)
+              .frame(width: 90, height: 90)
+              .background(Color.n10)
+              .clipShape(RoundedRectangle(cornerRadius: 8))
+          } else {
+            notImagePlaceholder
+          }
+        }
+      } else {
+        notImagePlaceholder
+      }
+    }
+  }
+
+  private var faviconURL: URL? {
+    guard let linkURL, let host = URL(string: linkURL)?.host else { return nil }
+    return URL(string: "https://\(host)/favicon.ico")
+  }
+
+  private var notImagePlaceholder: some View {
+    DesignSystemAsset.notImage.swiftUIImage
+      .resizable()
+      .aspectRatio(contentMode: .fill)
+      .frame(width: 90, height: 90)
+      .foregroundStyle(.gray)
+      .clipped()
+      .clipShape(RoundedRectangle(cornerRadius: 8))
   }
 
   var editButton: some View {

--- a/TapTap/Projects/DesignSystem/Sources/macOS/Card/MacArticleCard/MacArticleCard.swift
+++ b/TapTap/Projects/DesignSystem/Sources/macOS/Card/MacArticleCard/MacArticleCard.swift
@@ -19,6 +19,7 @@ public struct MacArticleCard: View {
   let title: String
   let categoryName: String?
   let imageURL: String?
+  let linkURL: String?
   let dateString: String
   let isEditing: Bool
   @Binding var isSelected: Bool
@@ -36,6 +37,7 @@ public struct MacArticleCard: View {
     title: String,
     categoryName: String?,
     imageURL: String?,
+    linkURL: String? = nil,
     dateString: String,
     isEditing: Bool = false,
     isSelected: Binding<Bool> = .constant(false),
@@ -46,6 +48,7 @@ public struct MacArticleCard: View {
     self.title = title
     self.categoryName = categoryName
     self.imageURL = imageURL
+    self.linkURL = linkURL
     self.dateString = dateString
     self.isEditing = isEditing
     self._isSelected = isSelected

--- a/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Views/LinkDetailView.swift
+++ b/TapTap/Projects/MacFeature/LinkDetailFeature/Sources/Views/LinkDetailView.swift
@@ -165,7 +165,11 @@ private extension LinkDetailView {
 
   func openOriginalLink() {
     guard let url = URL(string: viewModel.article.urlString) else { return }
-    NSWorkspace.shared.open(url)
+    if let safariURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.Safari") {
+      NSWorkspace.shared.open([url], withApplicationAt: safariURL, configuration: NSWorkspace.OpenConfiguration())
+    } else {
+      NSWorkspace.shared.open(url)
+    }
   }
 
   func closeMemoPanel() {

--- a/TapTap/Projects/MacFeature/LinkListFeature/Sources/Views/LinkListView.swift
+++ b/TapTap/Projects/MacFeature/LinkListFeature/Sources/Views/LinkListView.swift
@@ -75,6 +75,7 @@ private extension LinkListView {
             title: article.title,
             categoryName: article.category?.categoryName,
             imageURL: article.imageURL,
+            linkURL: article.urlString,
             dateString: viewModel.formattedDate(article.createAt),
             isEditing: viewModel.isEditing,
             isSelected: isSelected,

--- a/TapTap/Projects/TapTapMac/MacSafariExtension.entitlements
+++ b/TapTap/Projects/TapTapMac/MacSafariExtension.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.application-groups</key>
+  <array>
+    <string>group.com.nbs.dev.ADA.shared</string>
+  </array>
+</dict>
+</plist>

--- a/TapTap/Projects/TapTapMac/MacSafariExtension/Info.plist
+++ b/TapTap/Projects/TapTapMac/MacSafariExtension/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>탭탭</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key>
+	<string>탭탭</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.Safari.web-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
+	</dict>
+</dict>
+</plist>

--- a/TapTap/Projects/TapTapMac/Project.swift
+++ b/TapTap/Projects/TapTapMac/Project.swift
@@ -8,6 +8,27 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
+let macSafariExtensionTarget = Target.target(
+  name: "MacSafariExtension",
+  destinations: .macOS,
+  product: .appExtension,
+  deploymentTargets: .macOS("15.0"),
+  infoPlist: .file(path: "MacSafariExtension/Info.plist"),
+  sources: [
+    "../App/SafariExtension/Sources/**",
+    "../Core/Sources/**"
+  ],
+  resources: [
+    "../App/SafariExtension/Resources/manifest.json",
+    "../App/SafariExtension/Resources/popup.html",
+    "../App/SafariExtension/Resources/*.js",
+    "../App/SafariExtension/Resources/*.css",
+    "../App/SafariExtension/Resources/images/**",
+    "../App/SafariExtension/Resources/_locales/**"
+  ],
+  entitlements: .file(path: "MacSafariExtension.entitlements")
+)
+
 let project = Project.project(
   name: Module.TapTapMac.rawValue,
   targets: [
@@ -24,6 +45,7 @@ let project = Project.project(
       resources: .default,
       entitlements: .file(path: "TapTapMac.entitlements"),
       dependencies: [
+        .target(name: "MacSafariExtension"),
         .core(),
         .designSystem(),
         .macSearchFeature(),
@@ -32,6 +54,7 @@ let project = Project.project(
         .macLinkListFeature(),
         .macLinkDetailFeature()
       ]
-    )
+    ),
+    macSafariExtensionTarget
   ]
 )

--- a/TapTap/Tuist/ProjectDescriptionHelpers/Target+Templates.swift
+++ b/TapTap/Tuist/ProjectDescriptionHelpers/Target+Templates.swift
@@ -123,8 +123,13 @@ extension Target {
       }
       
     case .appExtension:
-      debugSettings["PRODUCT_BUNDLE_IDENTIFIER"] = "\(Project.bundleIDBase).\(name)"
-      releaseSettings["PRODUCT_BUNDLE_IDENTIFIER"] = "\(Project.bundIDAppStore).\(name == "shareExtension" ? "actionExtension" : "safariExtension")"
+      if name == "MacSafariExtension" {
+        debugSettings["PRODUCT_BUNDLE_IDENTIFIER"] = "\(Project.macOSbundleID).safariExtension"
+        releaseSettings["PRODUCT_BUNDLE_IDENTIFIER"] = "\(Project.macOSbundleIDAppStore).safariExtension"
+      } else {
+        debugSettings["PRODUCT_BUNDLE_IDENTIFIER"] = "\(Project.bundleIDBase).\(name)"
+        releaseSettings["PRODUCT_BUNDLE_IDENTIFIER"] = "\(Project.bundIDAppStore).\(name == "shareExtension" ? "actionExtension" : "safariExtension")"
+      }
       debugSettings["PROVISIONING_PROFILE_SPECIFIER"] = "$(PROV_PROFILE_\(name.uppercased())_DEV)"
       releaseSettings["PROVISIONING_PROFILE_SPECIFIER"] = "$(PROV_PROFILE_\(name.uppercased())_RELEASE)"
       

--- a/TapTap/fastlane/fastfile
+++ b/TapTap/fastlane/fastfile
@@ -221,7 +221,7 @@ platform :macos do
   lane :dev do
     match(
       type: "development",
-      app_identifier: "com.Nbs.dev.taptap.macOS",
+      app_identifier: ["com.Nbs.dev.taptap.macOS", "com.Nbs.dev.taptap.macOS.safariExtension"],
       platform: "macos"
     )
   end
@@ -230,7 +230,7 @@ platform :macos do
   lane :release do
     match(
       type: "appstore",
-      app_identifier: "com.Nbs.dev.ADA.macOS",
+      app_identifier: ["com.Nbs.dev.ADA.macOS", "com.Nbs.dev.ADA.macOS.safariExtension"],
       platform: "macos"
     )
   end
@@ -244,7 +244,7 @@ platform :macos do
     # macOS 앱스토어 .pkg 서명에는 앱 배포 인증서 + Installer 인증서가 둘 다 필요하다.
     match(
       type: "appstore",
-      app_identifier: app_identifier,
+      app_identifier: [app_identifier, "#{app_identifier}.safariExtension"],
       platform: "macos",
       additional_cert_types: ["mac_installer_distribution"]
     )


### PR DESCRIPTION
## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #125

---

### 🧶 주요 변경 내용 (Summary)

- **macOS 사파리 익스텐션 타겟 추가** (`MacSafariExtension`): iOS 익스텐션의 핸들러/웹 리소스를 그대로 재사용. Tuist가 macOS appExtension → staticFramework 의존을 허용하지 않아 Core는 소스로 직접 컴파일 (핸들러의 `import Core`는 `#if os(iOS)` 가드)
- **macOS 마우스 입력 대응**: 더블클릭으로 하이라이트 생성/삭제 (`dblclick`, 터치 미지원 환경 전용), 메모 입력창 포커스/닫힘 문제 수정
- **메모 저장 버그 수정 (iOS 공통)**: 메모 id 숫자/문자열 타입 불일치로 수정·삭제가 localStorage에 반영되지 않던 문제, 캡슐 중복 렌더링 수정
- **하이라이트 자동 동기화 (macOS 전용)**: 하이라이트/메모 변경 시 네이티브 핸들러가 앱 그룹 SwiftData에 자동 저장. 미저장 페이지는 미분류 링크로 자동 생성, og:image 기반 썸네일 추출 포함. manifest에 `nativeMessaging` 권한 추가
- **맥 링크 카드 썸네일 개선**: imageURL 없음/로드 실패 시 무한 스피너 → 사이트 파비콘 폴백 → notImage 순서로 표시
- **링크 원문보기**: 기본 브라우저 대신 항상 Safari로 열기 (하이라이트 익스텐션 연계)
- fastlane macOS 레인에 익스텐션 번들 ID 프로파일 동기화 추가

---

### 🧪 테스트 / 검증 내역

- [x] TapTapMac / TapTap(iOS) 빌드 성공
- [x] macOS Safari에서 더블클릭 하이라이트, 메모 입력/수정/삭제 동작 확인
- [x] 하이라이트 시 맥 앱에 링크+하이라이트 자동 저장 확인
- [x] 인스타그램 등 썸네일 없는 링크 파비콘 폴백 확인
- [ ] iOS 회귀 테스트 (메모 수정 → 공유 저장 시 수정본 반영 확인 필요)

---

### 💬 기타 공유 사항

- `Tuist/Config/Project.xcconfig`는 gitignore라 아래 두 줄을 각자 로컬에 추가해야 macOS 익스텐션 서명이 됩니다:
  ```
  PROV_PROFILE_MACSAFARIEXTENSION_DEV = match Development com.Nbs.dev.taptap.macOS.safariExtension macos
  PROV_PROFILE_MACSAFARIEXTENSION_RELEASE = match AppStore com.Nbs.dev.ADA.macOS.safariExtension macos
  ```
  (match 저장소에 프로파일은 생성해뒀습니다)
- 메모 id 타입 버그는 iOS에도 있던 것이라, iOS에서도 수정 전 메모가 앱에 저장되던 문제가 함께 해결됩니다
- iOS 자동 동기화 적용 여부는 별도 논의 예정 (현재는 macOS만)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fa4ZCdMegd7dL8sHiZq8V


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Safari 확장에서 웹 페이지 하이라이트와 메모를 앱과 동기화합니다.
  * macOS용 Safari 확장을 지원합니다.
  * 터치 기기와 마우스 환경에서 더블탭·더블클릭으로 하이라이트를 생성할 수 있습니다.
  * 문서 미리보기에서 대표 이미지가 없거나 로드되지 않으면 파비콘을 표시합니다.

* **버그 수정**
  * 하이라이트 교체 및 메모 수정·삭제의 안정성을 개선했습니다.
  * 문장 선택, 툴팁, 메모 입력 동작을 개선했습니다.
  * Safari가 없는 환경에서도 원본 링크를 열 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->