### PR TITLE
🔧 Chore: #125 맥 앱 버전 키 추가 (TestFlight export 수정)

### DIFF
--- a/TapTap/Projects/TapTapMac/Project.swift
+++ b/TapTap/Projects/TapTapMac/Project.swift
@@ -38,8 +38,11 @@ let project = Project.project(
       product: .app,
       deploymentTargets: .macOS("15.0"),
       // macOS 앱스토어 업로드에는 LSApplicationCategoryType이 필수다. (altool 90242)
+      // 버전 키가 없으면 Tuist 기본값(1.0/1)으로 고정되어 익스텐션 버전과 어긋난다.
       infoPlist: .extendingDefault(with: [
-        "LSApplicationCategoryType": "public.app-category.productivity"
+        "LSApplicationCategoryType": "public.app-category.productivity",
+        "CFBundleShortVersionString": "$(MARKETING_VERSION)",
+        "CFBundleVersion": "$(CURRENT_PROJECT_VERSION)"
       ]),
       sources: .sources,
       resources: .default,


### PR DESCRIPTION
## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Related #125

### 🧶 주요 변경 내용 (Summary)
- TapTapMac 타겟 Info.plist에 `CFBundleShortVersionString`/`CFBundleVersion` 키 추가
- 키가 없으면 Tuist 기본값(1.0/1)으로 고정되어 사파리 익스텐션 버전과 어긋나 App Store export가 거부됨 (macOS TestFlight 1.1.0 업로드 중 발견)

### 🧪 테스트 / 검증 내역
- [x] macOS TestFlight 1.1.0 (build 1) 업로드 성공으로 검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fa4ZCdMegd7dL8sHiZq8V